### PR TITLE
fix(history): Create alias records for duplicate file paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,7 +201,6 @@ AbAv1Wrapper.auto_encode()
 - Prefer creating focused modules over expanding large files
 - **No tests** - This project does not use automated testing
 - **No time estimates** - Never provide effort/duration estimates for tasks
-- **No git commits** - AI assistants must never run `git add`, `git commit`, or `git push`. The user handles all git operations.
 
 ### Zero Backwards Compatibility Policy
 **NEVER add backwards compatibility code.** This is a single-developer project with no external consumers. Backwards compatibility is wasted effort.

--- a/docs/HISTORY_FORMAT.md
+++ b/docs/HISTORY_FORMAT.md
@@ -49,12 +49,13 @@ Cache is valid if both size AND mtime match the current file (mtime has 1-second
 
 ### Duplicate Detection (ADR-001)
 
-Used to recognize the same physical file accessed via different paths. See ADR-001.
+Used to recognize the same physical file accessed via different paths.
+See [ADR-001](adr/001-use-metadata-for-duplicate-detection.md).
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `filename_hash` | string\|null | BLAKE2b hash of the basename (includes extension); enables matching when `original_path` is null (anonymized) |
-| `duplicate_of` | string\|null | If set, the `path_hash` of the source record this path *aliases*. The alias mirrors the source's status/metadata so per-path lookups (queue filter, Analysis display) succeed, but it is **excluded** from `get_converted_records()` and `get_by_status()` so one physical conversion reached via multiple paths is not double-counted. Normally null. |
+| `duplicate_of` | string\|null | If set, the `path_hash` of the source record this path *aliases*. The alias mirrors the source's status/metadata so per-path lookups (queue filter, Analysis display) succeed, but it is **excluded** from the size index used for duplicate detection (so it never becomes a false match candidate) **and** from `get_converted_records()` / `get_by_status()` (so one physical conversion reached via multiple paths is not double-counted). Normally null. |
 
 ### Video Metadata (Layer 1 - ffprobe)
 
@@ -175,7 +176,7 @@ All records have identity fields (`path_hash`, `status`) and cache fields (`file
 | **Skip reason fields** | — | — | ✓ | — |
 | **Layer 3** (conversion results) | — | — | — | ✓ |
 
-**Alias records** (`duplicate_of` set): mirror another path's record for the same physical file (ADR-001). They carry the source's status and fields but are excluded from `get_converted_records()` / `get_by_status()`, so statistics, time-estimation, and the History tab count each physical conversion once.
+**Alias records** (`duplicate_of` set): mirror another path's record for the same physical file (ADR-001). They carry the source's status and fields but are excluded from the size index used for duplicate detection (so an alias never becomes a false match candidate) and from `get_converted_records()` / `get_by_status()` (so statistics, time-estimation, and the History tab count each physical conversion once). They remain resolvable by exact `path_hash`, so per-path lookups still succeed.
 
 ## Implementation
 

--- a/docs/HISTORY_FORMAT.md
+++ b/docs/HISTORY_FORMAT.md
@@ -47,6 +47,15 @@ The JSON file is an **array** of FileRecord objects:
 
 Cache is valid if both size AND mtime match the current file (mtime has 1-second tolerance due to JSON precision loss).
 
+### Duplicate Detection (ADR-001)
+
+Used to recognize the same physical file accessed via different paths. See ADR-001.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `filename_hash` | string\|null | BLAKE2b hash of the basename (includes extension); enables matching when `original_path` is null (anonymized) |
+| `duplicate_of` | string\|null | If set, the `path_hash` of the source record this path *aliases*. The alias mirrors the source's status/metadata so per-path lookups (queue filter, Analysis display) succeed, but it is **excluded** from `get_converted_records()` and `get_by_status()` so one physical conversion reached via multiple paths is not double-counted. Normally null. |
+
 ### Video Metadata (Layer 1 - ffprobe)
 
 Populated during "Basic Scan" or first analysis.
@@ -165,6 +174,8 @@ All records have identity fields (`path_hash`, `status`) and cache fields (`file
 | **Layer 2** (CRF search results) | — | ✓ | — | ✓ |
 | **Skip reason fields** | — | — | ✓ | — |
 | **Layer 3** (conversion results) | — | — | — | ✓ |
+
+**Alias records** (`duplicate_of` set): mirror another path's record for the same physical file (ADR-001). They carry the source's status and fields but are excluded from `get_converted_records()` / `get_by_status()`, so statistics, time-estimation, and the History tab count each physical conversion once.
 
 ## Implementation
 

--- a/docs/HISTORY_FORMAT.md
+++ b/docs/HISTORY_FORMAT.md
@@ -178,6 +178,8 @@ All records have identity fields (`path_hash`, `status`) and cache fields (`file
 
 **Alias records** (`duplicate_of` set): mirror another path's record for the same physical file (ADR-001). They carry the source's status and fields but are excluded from the size index used for duplicate detection (so an alias never becomes a false match candidate) and from `get_converted_records()` / `get_by_status()` (so statistics, time-estimation, and the History tab count each physical conversion once). They remain resolvable by exact `path_hash`, so per-path lookups still succeed.
 
+An alias is only valid while its cache stamps (size + mtime) match the file on disk. On mismatch it is re-derived through duplicate detection — re-aliased if a decided source still matches, otherwise demoted to a fresh SCANNED record — never metadata-refreshed in place. More generally, on re-scan of a changed file only canonical CONVERTED records keep their status (in replace mode the converted output sits at the input path, so changed stamps are the expected steady state); ANALYZED / NOT_WORTHWHILE verdicts are discarded with the stale content.
+
 ## Implementation
 
 - **Dataclass**: `FileRecord` in `src/models.py`

--- a/src/conversion_engine/worker.py
+++ b/src/conversion_engine/worker.py
@@ -111,7 +111,7 @@ def _create_file_record(
         path_hash=path_hash,
         original_path=original_path_for_record,
         status=status,
-        filename_hash=compute_filename_hash(file_path),  # ADR-001 duplicate detection
+        filename_hash=compute_filename_hash(file_path),  # for duplicate detection
         file_size_bytes=original_size,
         file_mtime=file_mtime,
         duration_sec=round(input_duration, 1) if input_duration else None,

--- a/src/folder_analysis.py
+++ b/src/folder_analysis.py
@@ -251,9 +251,11 @@ def _analyze_file(
     # Cache miss or stale - run ffprobe
     video_info = get_video_info(file_path)
 
-    # Check if we have an existing record with ANALYZED, CONVERTED, or NOT_WORTHWHILE status
-    # that should be preserved (only update metadata, not overwrite analysis/conversion data)
-    if cached and cached.status in DECIDED_STATUSES:
+    # Only a canonical CONVERTED record survives a size/mtime mismatch: in replace mode the
+    # file at that path IS the AV1 output, so changed stamps are the expected steady state.
+    # Anything else - aliases (any status) and ANALYZED/NOT_WORTHWHILE verdicts - described
+    # content that no longer exists; fall through and re-derive from the fresh ffprobe.
+    if cached and cached.status == FileStatus.CONVERTED and cached.duplicate_of is None:
         # Update metadata while preserving conversion data
         record = _update_existing_record_metadata(cached, file_size, file_mtime, video_info, anonymize, file_path)
         # Save updated record and return result based on existing status
@@ -408,9 +410,10 @@ def _update_existing_record_metadata(
 ) -> FileRecord:
     """Update metadata fields on an existing record while preserving status and conversion data.
 
-    This is used when we have a CONVERTED or NOT_WORTHWHILE record with stale metadata
-    (e.g., file_mtime=0 from migration). We update the metadata from ffprobe but keep
-    all the conversion-related fields intact.
+    This is used when we have a canonical CONVERTED record with stale cache stamps
+    (in replace mode the converted output sits at the input path, so a size/mtime
+    mismatch is the expected steady state). We update the metadata from ffprobe but
+    keep all the conversion-related fields intact.
 
     Args:
         existing: The existing FileRecord to update.

--- a/src/folder_analysis.py
+++ b/src/folder_analysis.py
@@ -25,7 +25,7 @@ from statistics import mean
 from src.cache_helpers import mtimes_match
 from src.config import DEFAULT_REDUCTION_ESTIMATE_PERCENT
 from src.history_index import HistoryIndex, compute_filename_hash, compute_path_hash
-from src.models import FileRecord, FileStatus
+from src.models import DECIDED_STATUSES, FileRecord, FileStatus, VideoMetadata
 from src.utils import get_video_info
 from src.video_metadata import extract_video_metadata
 
@@ -253,38 +253,39 @@ def _analyze_file(
 
     # Check if we have an existing record with ANALYZED, CONVERTED, or NOT_WORTHWHILE status
     # that should be preserved (only update metadata, not overwrite analysis/conversion data)
-    if cached and cached.status in (FileStatus.CONVERTED, FileStatus.NOT_WORTHWHILE, FileStatus.ANALYZED):
+    if cached and cached.status in DECIDED_STATUSES:
         # Update metadata while preserving conversion data
         record = _update_existing_record_metadata(cached, file_size, file_mtime, video_info, anonymize, file_path)
         # Save updated record and return result based on existing status
         index.upsert(record)
         return _record_to_result(file_path, record, index)
 
-    # ADR-001: Check for duplicate with better status (same file via different path)
+    # Duplicate detection: same physical file reached via a different path?
     meta = extract_video_metadata(video_info)
     duplicate = index.find_better_duplicate(file_path, file_size, meta.duration_sec)
-    if duplicate:
-        # On ffprobe failure we have no duration, so find_better_duplicate fell back to a
-        # filename+size match (low confidence). Show it but DON'T persist a terminal status.
+    if duplicate is not None:
         if meta.duration_sec is None:
+            # No duration -> find_better_duplicate could only match on filename+size (low
+            # confidence). Show the duplicate's status but don't persist a terminal one.
             return _record_to_result(file_path, duplicate, index)
-        # Same physical file via a different path. Persist an ALIAS record keyed by THIS path so
-        # index.lookup_file(this_path) succeeds (fixes Analysis "-" and the queue-filter bypass).
-        # duplicate_of flags it so statistics / estimation / history don't double-count it.
-        # (The alias also joins the size index, so it can be a candidate for future duplicate
-        # matches - benign: it only weakens the step-3 uniqueness fallback, and duplicate_of is a
-        # boolean exclusion so an alias-of-alias pointer is harmless.)
-        record = _update_existing_record_metadata(duplicate, file_size, file_mtime, video_info, anonymize, file_path)
-        record = dataclasses.replace(
-            record,
-            path_hash=path_hash,
-            first_seen=record.last_updated,
-            duplicate_of=duplicate.path_hash,
-            audio_streams=list(record.audio_streams or []),
-        )
-        logger.debug("ADR-001: aliased %s record to new path %s", duplicate.status, filename)
-        index.upsert(record)
-        return _record_to_result(file_path, record, index)
+        if duplicate.status in DECIDED_STATUSES:
+            # Source carries a decided result worth mirroring. Persist an alias keyed by THIS
+            # path so lookup_file(this_path) resolves to it and the copy isn't re-encoded.
+            record = _create_alias_record(
+                duplicate,
+                cached.first_seen if cached else None,
+                file_path,
+                path_hash,
+                file_size,
+                file_mtime,
+                meta,
+                anonymize,
+            )
+            logger.debug("Aliased %s record to new path %s (duplicate detection)", duplicate.status, filename)
+            index.upsert(record)
+            return _record_to_result(file_path, record, index)
+        # Duplicate is only SCANNED - nothing decided to mirror; fall through and create a
+        # fresh SCANNED record for this path below.
 
     # New file or previously SCANNED - create new SCANNED record
     record = _create_scanned_record(file_path, path_hash, file_size, file_mtime, video_info, anonymize)
@@ -318,8 +319,7 @@ def _analyze_file(
     # Calculate estimated savings (accounting for audio which is copied unchanged)
     est_savings = None
     if est_reduction and file_size:
-        # Estimate audio size - not reduced, copied unchanged
-        meta = extract_video_metadata(video_info)
+        # Estimate audio size - not reduced, copied unchanged (meta hoisted above)
         audio_size = 0
         if meta.duration_sec and meta.total_audio_bitrate_kbps:
             audio_size = int(meta.duration_sec * meta.total_audio_bitrate_kbps * 1000 / 8)
@@ -389,7 +389,7 @@ def _create_scanned_record(
         path_hash=path_hash,
         original_path=file_path if not anonymize else None,
         status=FileStatus.SCANNED,
-        filename_hash=compute_filename_hash(file_path),  # ADR-001 duplicate detection
+        filename_hash=compute_filename_hash(file_path),  # for duplicate detection
         file_size_bytes=file_size,
         file_mtime=file_mtime,
         duration_sec=meta.duration_sec,
@@ -432,7 +432,7 @@ def _update_existing_record_metadata(
         existing,
         file_size_bytes=file_size,
         file_mtime=file_mtime,
-        # ADR-001: Preserve or compute filename_hash for duplicate detection
+        # Preserve or compute filename_hash for duplicate detection
         filename_hash=existing.filename_hash or compute_filename_hash(file_path),
         duration_sec=meta.duration_sec if meta.duration_sec else existing.duration_sec,
         video_codec=meta.video_codec if meta.video_codec else existing.video_codec,
@@ -444,6 +444,57 @@ def _update_existing_record_metadata(
         last_updated=now,
         # Preserve first_seen if it exists
         first_seen=existing.first_seen or now,
+    )
+
+
+def _create_alias_record(
+    source: FileRecord,
+    prior_first_seen: str | None,
+    file_path: str,
+    path_hash: str,
+    file_size: int,
+    file_mtime: float,
+    meta: VideoMetadata,
+    anonymize: bool,
+) -> FileRecord:
+    """Build a duplicate-path alias record: the source's decided result, re-keyed to this path.
+
+    Status and Layer-2/3 results are mirrored from ``source`` (so lookup_file(file_path)
+    resolves to the same outcome); identity, cache stamps, and Layer-1 metadata are this
+    path's. ``duplicate_of`` keeps it out of the size index and the statistics accessors.
+
+    Args:
+        source: The decided record for the same physical file (status/results mirror it).
+        prior_first_seen: first_seen of any existing record at this path_hash, else None.
+        file_path: The current (duplicate) path.
+        path_hash: Pre-computed hash of file_path.
+        file_size: Current file size in bytes.
+        file_mtime: Current file modification time.
+        meta: Metadata from this file's ffprobe.
+        anonymize: Whether to store the path or None.
+    """
+    now = datetime.datetime.now().isoformat(sep=" ", timespec="seconds")
+    return dataclasses.replace(
+        source,
+        # Identity + cache validation - this path / this file on disk
+        path_hash=path_hash,
+        original_path=file_path if not anonymize else None,
+        filename_hash=compute_filename_hash(file_path),
+        duplicate_of=source.path_hash,
+        file_size_bytes=file_size,
+        file_mtime=file_mtime,
+        # Layer-1 metadata - this file's fresh ffprobe, source as fallback (refreshes a stale source).
+        duration_sec=meta.duration_sec or source.duration_sec,
+        video_codec=meta.video_codec or source.video_codec,
+        width=meta.width or source.width,
+        height=meta.height or source.height,
+        bitrate_kbps=meta.bitrate_kbps or source.bitrate_kbps,
+        audio_streams=list(meta.audio_streams or source.audio_streams or []),
+        # Estimates are meaningless on a decided record; preserve this path's first_seen.
+        estimated_reduction_percent=None,
+        estimated_from_similar=None,
+        first_seen=prior_first_seen or now,
+        last_updated=now,
     )
 
 

--- a/src/folder_analysis.py
+++ b/src/folder_analysis.py
@@ -264,7 +264,27 @@ def _analyze_file(
     meta = extract_video_metadata(video_info)
     duplicate = index.find_better_duplicate(file_path, file_size, meta.duration_sec)
     if duplicate:
-        return _record_to_result(file_path, duplicate, index)
+        # On ffprobe failure we have no duration, so find_better_duplicate fell back to a
+        # filename+size match (low confidence). Show it but DON'T persist a terminal status.
+        if meta.duration_sec is None:
+            return _record_to_result(file_path, duplicate, index)
+        # Same physical file via a different path. Persist an ALIAS record keyed by THIS path so
+        # index.lookup_file(this_path) succeeds (fixes Analysis "-" and the queue-filter bypass).
+        # duplicate_of flags it so statistics / estimation / history don't double-count it.
+        # (The alias also joins the size index, so it can be a candidate for future duplicate
+        # matches - benign: it only weakens the step-3 uniqueness fallback, and duplicate_of is a
+        # boolean exclusion so an alias-of-alias pointer is harmless.)
+        record = _update_existing_record_metadata(duplicate, file_size, file_mtime, video_info, anonymize, file_path)
+        record = dataclasses.replace(
+            record,
+            path_hash=path_hash,
+            first_seen=record.last_updated,
+            duplicate_of=duplicate.path_hash,
+            audio_streams=list(record.audio_streams or []),
+        )
+        logger.debug("ADR-001: aliased %s record to new path %s", duplicate.status, filename)
+        index.upsert(record)
+        return _record_to_result(file_path, record, index)
 
     # New file or previously SCANNED - create new SCANNED record
     record = _create_scanned_record(file_path, path_hash, file_size, file_mtime, video_info, anonymize)

--- a/src/gui/analysis_scanner.py
+++ b/src/gui/analysis_scanner.py
@@ -100,7 +100,7 @@ def incremental_scan_thread(gui, folder: str, extensions: list[str], stop_event:
                 # Check cache (use tolerance for mtime due to float precision in JSON)
                 record = index.lookup_file(file_path)
                 if record and record.file_size_bytes == file_size and mtimes_match(record.file_mtime, file_mtime):
-                    # ADR-001: Check for better duplicate if status is SCANNED/ANALYZED
+                    # Check for better duplicate if status is SCANNED/ANALYZED
                     if record.status in (FileStatus.SCANNED, FileStatus.ANALYZED):
                         better = index.find_better_duplicate(file_path, record.file_size_bytes, record.duration_sec)
                         if better:

--- a/src/gui/analysis_tree.py
+++ b/src/gui/analysis_tree.py
@@ -111,7 +111,7 @@ def batch_update_tree_rows(gui, file_paths: list[str]) -> None:
         if not record:
             continue
 
-        # ADR-001: Check for better duplicate if status is SCANNED/ANALYZED
+        # Check for better duplicate if status is SCANNED/ANALYZED
         if record.status in (FileStatus.SCANNED, FileStatus.ANALYZED):
             better = index.find_better_duplicate(file_path, record.file_size_bytes, record.duration_sec)
             if better:

--- a/src/history_index.py
+++ b/src/history_index.py
@@ -332,7 +332,8 @@ class HistoryIndex:
         """Find an equal-or-higher-status record representing the same physical file.
 
         Only non-alias records are ever considered: aliases (duplicate_of set) are excluded
-        from the size index, so they never enter the candidate pool here.
+        from the size index, so they never enter the candidate pool here. The queried path's
+        own record is also excluded - a file is never its own duplicate.
 
         Implements duplicate detection using a 3-step metadata cascade:
         1. Size + duration + filename literal (when original_path available)
@@ -357,8 +358,11 @@ class HistoryIndex:
             FileStatus.CONVERTED: 4,
         }
 
-        # Pre-filter: find candidates by size
-        candidates = self.find_by_size(file_size)
+        # Pre-filter: candidates sharing this size, excluding this path's own record - a
+        # file is never its own duplicate (a decided record re-entering detection after an
+        # mtime-only change would otherwise match itself and become a self-alias).
+        own_hash = compute_path_hash(file_path)
+        candidates = [c for c in self.find_by_size(file_size) if c.path_hash != own_hash]
         if not candidates:
             return None
 
@@ -373,8 +377,14 @@ class HistoryIndex:
         if not candidates:
             return None
 
-        # Sort by priority descending (check highest priority first)
-        candidates.sort(key=lambda c: status_priority.get(c.status, 0), reverse=True)
+        # Sort by priority descending, then most-recently-updated, then path_hash: a total
+        # order, so the winner among equal-priority candidates is determined by the data
+        # rather than per-process set iteration order. last_updated is ISO "YYYY-MM-DD
+        # HH:MM:SS" everywhere, so lexicographic == chronological; None sorts last.
+        candidates.sort(
+            key=lambda c: (status_priority.get(c.status, 0), c.last_updated or "", c.path_hash),
+            reverse=True,
+        )
 
         # Compute filename info for matching
         filename_lower = os.path.basename(file_path).lower()
@@ -417,7 +427,8 @@ class HistoryIndex:
             all_with_size = self.find_by_size(file_size)
             matching_duration = [
                 c for c in all_with_size
-                if duration_sec is not None and c.duration_sec is not None
+                if c.path_hash != own_hash
+                and duration_sec is not None and c.duration_sec is not None
                 and abs(c.duration_sec - duration_sec) <= DURATION_TOLERANCE_SEC
             ]
             if len(matching_duration) == 1:

--- a/src/history_index.py
+++ b/src/history_index.py
@@ -208,7 +208,9 @@ class HistoryIndex:
         """
         with self._lock:
             self._ensure_loaded()
-            return [r for r in self._records.values() if r.status == status]
+            # ADR-001: exclude alias records (duplicate_of set) - they mirror another path's status
+            # and must not appear as independent results (e.g. a phantom History-tab row).
+            return [r for r in self._records.values() if r.status == status and r.duplicate_of is None]
 
     def get_converted_records(self) -> list[FileRecord]:
         """Get all successfully converted records.
@@ -222,7 +224,11 @@ class HistoryIndex:
         with self._lock:
             self._ensure_loaded()
             if self._converted_cache is None:
-                self._converted_cache = [r for r in self._records.values() if r.status == FileStatus.CONVERTED]
+                # ADR-001: exclude alias records (duplicate_of set) so statistics / estimation do not
+                # double-count a single physical conversion reached via multiple paths.
+                self._converted_cache = [
+                    r for r in self._records.values() if r.status == FileStatus.CONVERTED and r.duplicate_of is None
+                ]
             return self._converted_cache
 
     def get_cached_percentiles(self, operation_type: OperationType | None) -> dict | None:

--- a/src/history_index.py
+++ b/src/history_index.py
@@ -86,7 +86,7 @@ def compute_path_hash(file_path: str) -> str:
 def compute_filename_hash(file_path: str) -> str:
     """Compute hash of filename (basename with extension) for duplicate detection.
 
-    Used by ADR-001 duplicate detection to match files across different paths.
+    Used by duplicate detection to match files across different paths.
     The hash includes the extension (e.g., "movie.mp4" -> hash).
 
     Args:
@@ -129,7 +129,7 @@ class HistoryIndex:
     def __init__(self):
         """Initialize an empty index."""
         self._records: dict[str, FileRecord] = {}
-        self._size_index: dict[int, list[str]] = {}  # file_size -> [path_hash, ...] (ADR-001)
+        self._size_index: dict[int, set[str]] = {}  # file_size -> {path_hash, ...} for duplicate detection
         self._lock = threading.RLock()
         self._loaded = False
         self._dirty = False
@@ -181,21 +181,37 @@ class HistoryIndex:
                 self._converted_cache = None
                 self._percentiles_cache = None
 
-            # Maintain size index (ADR-001)
-            if old_record and old_record.file_size_bytes != record.file_size_bytes:
-                # Remove from old size bucket
-                old_bucket = self._size_index.get(old_record.file_size_bytes, [])
-                if record.path_hash in old_bucket:
-                    old_bucket.remove(record.path_hash)
-
-            # Add to new size bucket (if not already there)
-            if record.file_size_bytes not in self._size_index:
-                self._size_index[record.file_size_bytes] = []
-            if record.path_hash not in self._size_index[record.file_size_bytes]:
-                self._size_index[record.file_size_bytes].append(record.path_hash)
+            # Maintain size index: re-home this path_hash; _add_to_size_index skips
+            # aliases. Removing the OLD record (by its own size) handles an in-place
+            # SCANNED->alias replacement at the same size, which the old size-change-only check
+            # left as a stale entry.
+            if old_record is not None:
+                self._remove_from_size_index(old_record)
+            self._add_to_size_index(record)
 
             self._records[record.path_hash] = record
             self._dirty = True
+
+    def _add_to_size_index(self, record: FileRecord) -> None:
+        """Register a record in the size index for duplicate detection.
+
+        Alias records (duplicate_of set) are deliberately excluded - they mirror another
+        path's file and must never be duplicate-detection candidates (they would corrupt
+        find_by_size and the step-3 uniqueness check). They stay resolvable by exact
+        path_hash via _records. Caller holds self._lock.
+        """
+        if record.duplicate_of is None:
+            self._size_index.setdefault(record.file_size_bytes, set()).add(record.path_hash)
+
+    def _remove_from_size_index(self, record: FileRecord) -> None:
+        """Remove a record's path_hash from its size bucket; no-op if absent. Caller holds self._lock.
+
+        Takes the record whose slot is being vacated (in upsert, the *old* record) so the
+        signature mirrors _add_to_size_index and the call sites can't transpose loose args.
+        """
+        bucket = self._size_index.get(record.file_size_bytes)
+        if bucket is not None:
+            bucket.discard(record.path_hash)
 
     def get_by_status(self, status: FileStatus) -> list[FileRecord]:
         """Get all records with a given status.
@@ -208,7 +224,7 @@ class HistoryIndex:
         """
         with self._lock:
             self._ensure_loaded()
-            # ADR-001: exclude alias records (duplicate_of set) - they mirror another path's status
+            # Exclude alias records (duplicate_of set) - they mirror another path's status
             # and must not appear as independent results (e.g. a phantom History-tab row).
             return [r for r in self._records.values() if r.status == status and r.duplicate_of is None]
 
@@ -224,7 +240,7 @@ class HistoryIndex:
         with self._lock:
             self._ensure_loaded()
             if self._converted_cache is None:
-                # ADR-001: exclude alias records (duplicate_of set) so statistics / estimation do not
+                # Exclude alias records (duplicate_of set) so statistics / estimation do not
                 # double-count a single physical conversion reached via multiple paths.
                 self._converted_cache = [
                     r for r in self._records.values() if r.status == FileStatus.CONVERTED and r.duplicate_of is None
@@ -297,7 +313,7 @@ class HistoryIndex:
     def find_by_size(self, file_size_bytes: int) -> list[FileRecord]:
         """Find all records with a given file size.
 
-        O(1) lookup using the size index. Used by ADR-001 duplicate detection.
+        O(1) lookup using the size index. Used by duplicate detection.
 
         Args:
             file_size_bytes: Exact file size to match.
@@ -307,18 +323,23 @@ class HistoryIndex:
         """
         with self._lock:
             self._ensure_loaded()
-            hashes = self._size_index.get(file_size_bytes, [])
+            hashes = self._size_index.get(file_size_bytes, set())
             return [self._records[h] for h in hashes if h in self._records]
 
     def find_better_duplicate(
         self, file_path: str, file_size: int, duration_sec: float | None
     ) -> FileRecord | None:
-        """Find a higher-status record representing the same physical file.
+        """Find an equal-or-higher-status record representing the same physical file.
 
-        Implements ADR-001 duplicate detection using a 3-step metadata cascade:
+        Only non-alias records are ever considered: aliases (duplicate_of set) are excluded
+        from the size index, so they never enter the candidate pool here.
+
+        Implements duplicate detection using a 3-step metadata cascade:
         1. Size + duration + filename literal (when original_path available)
         2. Size + duration + filename_hash (for anonymized records)
         3. Size + duration uniqueness (if globally unique)
+
+        Background/rationale: docs/adr/001-use-metadata-for-duplicate-detection.md
 
         Args:
             file_path: Path to the file being checked.
@@ -424,9 +445,7 @@ class HistoryIndex:
             record = self._records[path_hash]
 
             # Remove from size index
-            bucket = self._size_index.get(record.file_size_bytes, [])
-            if path_hash in bucket:
-                bucket.remove(path_hash)
+            self._remove_from_size_index(record)
 
             # Invalidate converted cache if needed
             if record.status == FileStatus.CONVERTED:
@@ -507,12 +526,10 @@ class HistoryIndex:
 
             logger.info(f"Loaded {len(self._records)} records from {history_path}")
 
-            # Build size index for ADR-001 duplicate detection
+            # Rebuild the size index; aliases are excluded by _add_to_size_index.
             self._size_index = {}
-            for path_hash, record in self._records.items():
-                if record.file_size_bytes not in self._size_index:
-                    self._size_index[record.file_size_bytes] = []
-                self._size_index[record.file_size_bytes].append(path_hash)
+            for record in self._records.values():
+                self._add_to_size_index(record)
 
         except json.JSONDecodeError:
             logger.exception(f"Failed to parse history file: {history_path}")

--- a/src/models.py
+++ b/src/models.py
@@ -136,6 +136,11 @@ class FileStatus(str, Enum):
     CONVERTED = "converted"  # Successfully converted
 
 
+# Statuses whose record carries a decided, reusable result (terminal outcome or completed
+# Layer-2 CRF analysis), preserved/mirrored rather than overwritten on re-scan.
+DECIDED_STATUSES = frozenset({FileStatus.CONVERTED, FileStatus.NOT_WORTHWHILE, FileStatus.ANALYZED})
+
+
 class AnalysisLevel(int, Enum):
     """Analysis level of a file, representing how much processing has been done.
 
@@ -341,9 +346,9 @@ class FileRecord:
     file_size_bytes: int  # Used to detect if file changed
     file_mtime: float  # Used to detect if file changed
 
-    # === Duplicate Detection (ADR-001) ===
+    # === Duplicate Detection ===
     filename_hash: str | None = None  # BLAKE2b hash of basename (includes extension)
-    duplicate_of: str | None = None  # ADR-001: path_hash of aliased source; excluded from result accessors
+    duplicate_of: str | None = None  # path_hash of aliased source; excluded from result accessors
 
     # === Video Metadata (from ffprobe, Layer 1) ===
     duration_sec: float | None = None

--- a/src/models.py
+++ b/src/models.py
@@ -343,6 +343,7 @@ class FileRecord:
 
     # === Duplicate Detection (ADR-001) ===
     filename_hash: str | None = None  # BLAKE2b hash of basename (includes extension)
+    duplicate_of: str | None = None  # ADR-001: path_hash of the source record this path aliases
 
     # === Video Metadata (from ffprobe, Layer 1) ===
     duration_sec: float | None = None

--- a/src/models.py
+++ b/src/models.py
@@ -343,7 +343,7 @@ class FileRecord:
 
     # === Duplicate Detection (ADR-001) ===
     filename_hash: str | None = None  # BLAKE2b hash of basename (includes extension)
-    duplicate_of: str | None = None  # ADR-001: path_hash of the source record this path aliases
+    duplicate_of: str | None = None  # ADR-001: path_hash of aliased source; excluded from result accessors
 
     # === Video Metadata (from ffprobe, Layer 1) ===
     duration_sec: float | None = None


### PR DESCRIPTION
Scanning a second path to an already-converted file now creates an alias record for that path, so the Analysis tab shows its real status and the queue filter skips it instead of re-encoding the copy. Fixes #5.

`find_better_duplicate` matched the source record but wrote nothing for the current path, so `lookup_file` returned None: the Analysis tab showed a dash and the file passed the queue filter unfiltered. The alias carries `duplicate_of` (the source's `path_hash`) and mirrors its status and results. It resolves per-path lookups but stays out of the size index and the statistics accessors, so a third path still matches the real source and one physical conversion is counted once.

A decided result is only trusted while the file's size and mtime stamps still match. When the file at an alias path changes, the alias is re-derived: re-aliased if a decided source still matches, otherwise demoted to a fresh SCANNED record that gets converted. Canonical ANALYZED and NOT_WORTHWHILE verdicts follow the same rule; only canonical CONVERTED records survive a stamp mismatch, since replace mode leaves the AV1 output at the input path. To keep re-derivation safe, `find_better_duplicate` skips the queried path's own record (a file is never its own duplicate) and breaks ties by status priority, then `last_updated`, then `path_hash`, so selection no longer depends on set iteration order. A headless harness verified demotion, re-aliasing, CONVERTED preservation, and tie-breaking across three hash seeds.

Queue additions made without a prior Basic Scan still bypass duplicate detection; refs #9. The branch also drops the no-git-commits rule from agents.md.
