### PR TITLE
fix(queue): Preserve folder expand state with incremental tree updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ src/
     ├── analysis_scanner.py    # Incremental folder scanning with ffprobe
     ├── analysis_tree.py       # Analysis tree display/state management
     ├── queue_manager.py       # Queue item creation/categorization
-    ├── queue_tree.py          # Queue tree display/state management
+    ├── queue_tree.py          # Queue tree display: incremental in-place updates + full rebuild
     ├── tree_utils.py          # Tree expand/collapse utilities
     ├── tree_display.py        # Shared tree status formatting
     ├── tree_formatters.py     # Time/size/efficiency formatting and parsing
@@ -182,6 +182,8 @@ The queue supports two operation types via `OperationType` enum:
 - CONVERT: Calls `process_video()` (existing flow)
 - ANALYZE: Calls `wrapper.crf_search()`, updates history with Layer 2 data
 - Both: before processing, a duplicate short-circuit skips files already decided under another path (ADR-001), writing a `duplicate_of` alias — catches duplicates queued without a prior Basic Scan
+
+**Queue tree updates** (`gui/queue_tree.py`): status/value changes, operation changes, adds, removes, and drag reorders update rows in place (folder expand state, selection, and scroll survive). Full rebuild via `refresh_queue_tree()` is reserved for structural bulk ops (startup load, clear queue, clear completed, conflict replace) and restores expand state. See `docs/ARCHITECTURE.md` § Queue Tree Updates.
 
 ### Callback Flow
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -125,6 +125,25 @@ Conversion uses a queue-based architecture rather than direct folder scanning:
 
 `PENDING` → `CONVERTING` → `COMPLETED` / `ERROR` / `STOPPED`
 
+### Queue Tree Updates
+
+The queue tree (`gui/queue_tree.py`) updates incrementally so folder expand
+state, selection, and scroll position survive changes:
+
+| Change | Function | Strategy |
+|--------|----------|----------|
+| Status/estimate/output change | `refresh_queue_tree_values()` | Recompute values/tags of all rows in place |
+| Operation type change | `update_queue_item_row()` | Recompute one item + nested file rows |
+| Items added | `add_queue_items_to_tree()` | Append rows only |
+| Items removed | `remove_queue_items_from_tree()` | Delete rows, renumber the rest |
+| Drag-drop reorder | `sync_queue_order_from_tree()` | Renumber row text in place |
+| Structural bulk (startup load, clear queue, clear completed, conflict replace) | `refresh_queue_tree()` | Full rebuild; restores folder expand state keyed by queue item id |
+
+Row identity is tracked by stable queue-item-id → tree-iid maps
+(`_queue_tree_map`, `_tree_queue_map`, plus per-file maps); the incremental
+functions maintain these maps and fall back to a full rebuild if the tree
+has drifted from `_queue_items`.
+
 ## Threading Model
 
 ```

--- a/src/gui/conversion_controller.py
+++ b/src/gui/conversion_controller.py
@@ -430,7 +430,7 @@ def stop_conversion(gui) -> None:
         logger.info("Graceful stop requested (Stop After Current File). Signalling worker thread.")
         gui.stop_event.set()
         gui.stop_button.config(state="disabled")  # Disable button once stop is requested
-        gui.refresh_queue_tree()  # Show "Will skip" for pending items
+        gui.refresh_queue_tree_values()  # Show "Will skip" for pending items
     elif not gui.session.running:
         logger.info("Stop requested but conversion is not currently running.")
     elif gui.stop_event and gui.stop_event.is_set():
@@ -561,7 +561,7 @@ def restore_ui_after_stop(gui) -> None:
     update_ui_safely(gui.root, lambda: gui.stop_button.config(state="disabled"))
     update_ui_safely(gui.root, lambda: gui.force_stop_button.config(state="disabled"))
     update_ui_safely(gui.root, lambda: gui.clear_queue_button.config(state="normal"))
-    update_ui_safely(gui.root, gui.refresh_queue_tree)
+    update_ui_safely(gui.root, gui.refresh_queue_tree_values)
 
 
 def force_stop_conversion(gui, confirm: bool = True) -> None:
@@ -841,8 +841,8 @@ def conversion_complete(gui, final_message="Queue complete"):
         gui.root.after_cancel(s.elapsed_timer_id)
         s.elapsed_timer_id = None
 
-    # Refresh queue tree to update estimates and button states
-    gui.refresh_queue_tree()
+    # Refresh queue tree values to update estimates and button states
+    gui.refresh_queue_tree_values()
 
     # Refresh analysis tree to show correct done/skip counts and folder aggregates
     # (During conversion, callbacks fire before history is saved, causing stale data)

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -679,8 +679,24 @@ class VideoConverterGUI:
         queue_controller.on_browse_item_output_folder(self)
 
     def refresh_queue_tree(self):
-        """Refresh the queue tree view from _queue_items."""
+        """Rebuild the queue tree view from _queue_items."""
         queue_tree.refresh_queue_tree(self)
+
+    def refresh_queue_tree_values(self):
+        """Refresh all queue tree row values in place (preserves expand state)."""
+        queue_tree.refresh_queue_tree_values(self)
+
+    def update_queue_item_row(self, queue_item):
+        """Update a single queue item's tree row in place."""
+        queue_tree.update_queue_item_row(self, queue_item)
+
+    def add_queue_items_to_tree(self, new_items):
+        """Append tree rows for newly added queue items."""
+        queue_tree.add_queue_items_to_tree(self, new_items)
+
+    def remove_queue_items_from_tree(self, removed_items):
+        """Remove tree rows for queue items no longer in the queue."""
+        queue_tree.remove_queue_items_from_tree(self, removed_items)
 
     def sync_queue_order_from_tree(self):
         """Sync _queue_items order from the tree view after drag-drop reordering."""

--- a/src/gui/queue_controller.py
+++ b/src/gui/queue_controller.py
@@ -108,13 +108,12 @@ def on_remove_from_queue(gui) -> None:
     # Extract paths before removal for incremental sync
     removed_paths = extract_paths_from_queue_items(items_to_remove)
 
-    # Remove from queue
+    # Remove from queue (remove_queue_items_from_tree cleans _queue_items_by_id)
     for item in items_to_remove:
         gui._queue_items.remove(item)
-        gui._queue_items_by_id.pop(item.id, None)
 
     gui.save_queue_to_config()
-    gui.refresh_queue_tree()
+    gui.remove_queue_items_from_tree(items_to_remove)
     gui.sync_queue_tags_to_analysis_tree(removed_paths=removed_paths)
 
 
@@ -272,7 +271,7 @@ def on_item_suffix_changed(gui) -> None:
             queue_item.output_suffix = new_suffix
 
     gui.save_queue_to_config()
-    gui.refresh_queue_tree()
+    gui.refresh_queue_tree_values()
 
 
 def on_browse_item_output_folder(gui) -> None:
@@ -293,4 +292,4 @@ def on_browse_item_output_folder(gui) -> None:
             queue_item.output_folder = folder
 
     gui.save_queue_to_config()
-    gui.refresh_queue_tree()
+    gui.refresh_queue_tree_values()

--- a/src/gui/queue_manager.py
+++ b/src/gui/queue_manager.py
@@ -555,7 +555,11 @@ def add_items_to_queue(
     # Save and refresh if anything was added or modified
     if counts["added"] > 0 or counts["conflict_added"] > 0 or counts["conflict_replaced"] > 0:
         gui.save_queue_to_config()
-        gui.refresh_queue_tree()
+        if counts["conflict_replaced"] > 0:
+            # Replacement swaps an item mid-list; rebuild (preserves expand state)
+            gui.refresh_queue_tree()
+        else:
+            gui.add_queue_items_to_tree(items_added)
         added_paths = extract_paths_from_queue_items(items_added)
         gui.sync_queue_tags_to_analysis_tree(added_paths=added_paths)
 

--- a/src/gui/queue_tree.py
+++ b/src/gui/queue_tree.py
@@ -3,14 +3,20 @@
 """
 Queue tree display and state management.
 
-Handles full rebuilds of the queue tree view, including:
-- Queue item display with status, size, time estimates
-- Nested file display for folder items
-- Total row updates
-- Drag-drop reordering synchronization
+Provides incremental updates that modify rows in place, preserving folder
+expand state, selection, and scroll position:
+- refresh_queue_tree_values(): recompute values/tags for every row
+- update_queue_item_row(): single item and its nested file rows
+- add_queue_items_to_tree(): append-only insertion of new items
+- remove_queue_items_from_tree(): targeted deletion with renumbering
+
+refresh_queue_tree() remains the full delete-and-rebuild path for
+structural changes (startup load, clear operations, conflict replacement)
+and restores folder expand state across the rebuild.
 """
 
 import contextlib
+import logging
 import os
 
 from src.estimation import compute_grouped_percentiles, estimate_file_time
@@ -25,16 +31,27 @@ from src.history_index import compute_path_hash, get_history_index
 from src.models import OperationType, OutputMode, QueueItemStatus, TimeEstimate
 from src.utils import format_file_size
 
+logger = logging.getLogger(__name__)
+
 
 def refresh_queue_tree(gui) -> None:
-    """Refresh the queue tree view from _queue_items.
+    """Rebuild the queue tree from _queue_items.
 
-    Performs a full rebuild of the queue tree, updating all items
-    with current status, size, time estimates, and nested files.
+    Performs a full delete-and-rebuild, restoring folder expand state
+    (keyed by queue item id) afterwards. Selection and scroll position are
+    not preserved - use the incremental update functions for changes that
+    don't restructure the tree.
 
     Args:
         gui: The VideoConverterGUI instance.
     """
+    # Capture expand state before deleting rows (keyed by stable queue item id)
+    expanded_ids = {
+        queue_id
+        for queue_id, tree_id in gui._queue_tree_map.items()
+        if gui.queue_tree.exists(tree_id) and _is_expanded(gui.queue_tree, tree_id)
+    }
+
     # Clear existing items
     for item in gui.queue_tree.get_children():
         gui.queue_tree.delete(item)
@@ -44,76 +61,20 @@ def refresh_queue_tree(gui) -> None:
     gui._tree_file_map.clear()
     gui._queue_items_by_id = {item.id: item for item in gui._queue_items}
 
-    # Check if stop has been requested (pending items won't run)
-    stopping = gui.session.running and gui.stop_event is not None and gui.stop_event.is_set()
-
-    index = get_history_index()
-
-    # Pre-compute percentiles once for all estimates (see TIME_ESTIMATION.md ## Performance)
-    percentiles_by_op = {
-        OperationType.CONVERT: compute_grouped_percentiles(OperationType.CONVERT),
-        OperationType.ANALYZE: compute_grouped_percentiles(OperationType.ANALYZE),
-    }
-
-    # Pre-compute time estimates for all nested files (avoids 3x calls per file)
-    file_estimates: dict[str, TimeEstimate] = {}
-    for queue_item in gui._queue_items:
-        if queue_item.is_folder and queue_item.files:
-            op_type = queue_item.operation_type
-            percentiles = percentiles_by_op.get(op_type)
-            for file_item in queue_item.files:
-                if file_item.path not in file_estimates:
-                    file_estimates[file_item.path] = estimate_file_time(
-                        file_item.path, operation_type=op_type, grouped_percentiles=percentiles
-                    )
+    stopping, index, percentiles_by_op, file_estimates = _display_context(gui)
 
     # Add each queue item with order number
     for order, queue_item in enumerate(gui._queue_items, start=1):
-        # Get history record for metadata
-        path_hash = compute_path_hash(queue_item.source_path)
-        record = index.get(path_hash)
-
-        # Determine operation display based on operation type and Layer 2 data
-        operation_display = _format_operation_display(queue_item, record)
-
-        # Format output mode display
-        output_display = _format_output_display(queue_item, gui)
-
-        # Format codec/stream info
-        format_display = _format_format_display(queue_item, record)
-
-        # Format size - for folders, sum file sizes
-        size_display = _format_size_display(queue_item, record)
-
-        # Format estimated time
-        est_time_display = _format_time_estimate(queue_item, record, index, percentiles_by_op, file_estimates)
-
-        # Format status with tag
-        status_display, item_tag = format_queue_status_display(
-            queue_item.status,
-            stopping=stopping,
-            total_files=queue_item.total_files,
-            processed_files=queue_item.processed_files,
-        )
-        # Use the item's own format_status_display for non-stopping cases
-        if not stopping or queue_item.status != QueueItemStatus.PENDING:
-            if queue_item.status == QueueItemStatus.CONVERTING and queue_item.total_files > 0:
-                status_display = f"Converting ({queue_item.processed_files}/{queue_item.total_files})"
-            else:
-                status_display = queue_item.format_status_display()
-
-        # Insert item with order number prefix
-        icon = "📁" if queue_item.is_folder else "🎬"
-        # Only show expand arrow if folder has files to display
-        prefix = "▶ " if queue_item.is_folder and queue_item.files else ""
-        name = os.path.basename(queue_item.source_path)
+        values, item_tag = _build_item_values(gui, queue_item, stopping, index, percentiles_by_op, file_estimates)
+        expanded = queue_item.id in expanded_ids and bool(queue_item.is_folder and queue_item.files)
 
         item_id = gui.queue_tree.insert(
             "",
             "end",
-            text=f"{order}. {prefix}{icon} {name}",
-            values=(format_display, size_display, est_time_display, operation_display, output_display, status_display),
+            text=_item_text(queue_item, order, expanded=expanded),
+            values=values,
             tags=(item_tag,) if item_tag else (),
+            open=expanded,
         )
         gui._queue_tree_map[queue_item.id] = item_id
         gui._tree_queue_map[item_id] = queue_item.id
@@ -122,13 +83,152 @@ def refresh_queue_tree(gui) -> None:
         if queue_item.is_folder and queue_item.files:
             _insert_folder_file_rows(gui, queue_item, item_id, stopping, file_estimates)
 
-    # Update total row
     _update_total_row(gui, index, percentiles_by_op, file_estimates)
+    _update_button_states(gui)
 
-    # Update button states
-    update_clear_completed_button_state(gui)
-    update_remove_button_state(gui)
-    update_start_button_state(gui)
+
+def refresh_queue_tree_values(gui) -> None:
+    """Recompute display values and tags for every row in place.
+
+    Assumes the set and order of queue items is unchanged since the last
+    structural update. Updates all columns (status, estimates, operation,
+    output) without deleting rows, so expand state, selection, and scroll
+    position survive. Falls back to a full rebuild if the tree has drifted
+    from _queue_items.
+
+    Args:
+        gui: The VideoConverterGUI instance.
+    """
+    stopping, index, percentiles_by_op, file_estimates = _display_context(gui)
+
+    for queue_item in gui._queue_items:
+        tree_id = gui._queue_tree_map.get(queue_item.id)
+        if not tree_id or not gui.queue_tree.exists(tree_id):
+            logger.debug("Queue tree drifted from _queue_items; falling back to full rebuild")
+            refresh_queue_tree(gui)
+            return
+
+        values, item_tag = _build_item_values(gui, queue_item, stopping, index, percentiles_by_op, file_estimates)
+        gui.queue_tree.item(tree_id, values=values, tags=(item_tag,) if item_tag else ())
+
+        if queue_item.is_folder and queue_item.files:
+            _update_folder_file_rows(gui, queue_item, stopping, index, file_estimates)
+
+    _update_total_row(gui, index, percentiles_by_op, file_estimates)
+    _update_button_states(gui)
+
+
+def update_queue_item_row(gui, queue_item) -> None:
+    """Update a single queue item's row and nested file rows in place.
+
+    Recomputes all columns for the item (e.g., after an operation type
+    change) and refreshes the total row, since operation changes affect the
+    queue-wide time estimate. Falls back to a full rebuild if the item has
+    no tree row.
+
+    Args:
+        gui: The VideoConverterGUI instance.
+        queue_item: The QueueItem whose row should be updated.
+    """
+    tree_id = gui._queue_tree_map.get(queue_item.id)
+    if not tree_id or not gui.queue_tree.exists(tree_id):
+        logger.debug("No tree row for queue item %s; falling back to full rebuild", queue_item.id)
+        refresh_queue_tree(gui)
+        return
+
+    stopping, index, percentiles_by_op, file_estimates = _display_context(gui)
+
+    values, item_tag = _build_item_values(gui, queue_item, stopping, index, percentiles_by_op, file_estimates)
+    gui.queue_tree.item(tree_id, values=values, tags=(item_tag,) if item_tag else ())
+
+    if queue_item.is_folder and queue_item.files:
+        _update_folder_file_rows(gui, queue_item, stopping, index, file_estimates)
+
+    _update_total_row(gui, index, percentiles_by_op, file_estimates)
+    _update_button_states(gui)
+
+
+def add_queue_items_to_tree(gui, new_items) -> None:
+    """Append rows for newly added queue items without touching existing rows.
+
+    The new items must already be appended to _queue_items (in order, at the
+    tail). Falls back to a full rebuild if positions don't line up (e.g.,
+    an item was replaced mid-list).
+
+    Args:
+        gui: The VideoConverterGUI instance.
+        new_items: List of QueueItem objects that were appended to the queue.
+    """
+    if not new_items:
+        return
+
+    # Appending is only valid if the new items occupy the tail of _queue_items
+    # and every existing item already has a row
+    tail_ids = [item.id for item in gui._queue_items[-len(new_items):]]
+    existing_count = len(gui._queue_items) - len(new_items)
+    if tail_ids != [item.id for item in new_items] or existing_count != len(gui.queue_tree.get_children()):
+        logger.debug("New queue items are not a clean tail append; falling back to full rebuild")
+        refresh_queue_tree(gui)
+        return
+
+    stopping, index, percentiles_by_op, file_estimates = _display_context(gui)
+
+    order = existing_count
+    for queue_item in new_items:
+        order += 1
+        gui._queue_items_by_id[queue_item.id] = queue_item
+
+        values, item_tag = _build_item_values(gui, queue_item, stopping, index, percentiles_by_op, file_estimates)
+        item_id = gui.queue_tree.insert(
+            "",
+            "end",
+            text=_item_text(queue_item, order, expanded=False),
+            values=values,
+            tags=(item_tag,) if item_tag else (),
+        )
+        gui._queue_tree_map[queue_item.id] = item_id
+        gui._tree_queue_map[item_id] = queue_item.id
+
+        if queue_item.is_folder and queue_item.files:
+            _insert_folder_file_rows(gui, queue_item, item_id, stopping, file_estimates)
+
+    _update_total_row(gui, index, percentiles_by_op, file_estimates)
+    _update_button_states(gui)
+
+
+def remove_queue_items_from_tree(gui, removed_items) -> None:
+    """Remove specific queue item rows, renumber the rest, and refresh totals.
+
+    The items must already be removed from _queue_items. Other rows are left
+    untouched apart from their order-number prefix, so expand state,
+    selection, and scroll position survive.
+
+    Args:
+        gui: The VideoConverterGUI instance.
+        removed_items: List of QueueItem objects removed from the queue.
+    """
+    for queue_item in removed_items:
+        gui._queue_items_by_id.pop(queue_item.id, None)
+        tree_id = gui._queue_tree_map.pop(queue_item.id, None)
+        if tree_id:
+            gui._tree_queue_map.pop(tree_id, None)
+            if gui.queue_tree.exists(tree_id):
+                gui.queue_tree.delete(tree_id)  # Nested file rows are deleted with the parent
+        for file_item in queue_item.files:
+            file_tree_id = gui._queue_file_tree_map.pop(file_item.path, None)
+            if file_tree_id:
+                gui._tree_file_map.pop(file_tree_id, None)
+
+    if len(gui.queue_tree.get_children()) != len(gui._queue_items):
+        logger.debug("Queue tree drifted from _queue_items after removal; falling back to full rebuild")
+        refresh_queue_tree(gui)
+        return
+
+    _renumber_queue_rows(gui)
+
+    _stopping, index, percentiles_by_op, file_estimates = _display_context(gui)
+    _update_total_row(gui, index, percentiles_by_op, file_estimates)
+    _update_button_states(gui)
 
 
 def sync_queue_order_from_tree(gui) -> None:
@@ -155,12 +255,163 @@ def sync_queue_order_from_tree(gui) -> None:
 
     gui._queue_items = new_order
     gui.save_queue_to_config()
-    refresh_queue_tree(gui)
+    # Rows already sit in the new order after the drag; only the number prefixes are stale
+    _renumber_queue_rows(gui)
 
 
 # =============================================================================
 # Private Helper Functions
 # =============================================================================
+
+
+def _is_expanded(tree, tree_id: str) -> bool:
+    """Check a row's open state (Tk may return int, bool, or str)."""
+    return str(tree.item(tree_id, "open")) in ("1", "true", "True")
+
+
+def _item_text(queue_item, order: int, *, expanded: bool) -> str:
+    """Build the tree-column text for a top-level queue item row."""
+    icon = "📁" if queue_item.is_folder else "🎬"
+    # Only show expand arrow if folder has files to display
+    arrow = ""
+    if queue_item.is_folder and queue_item.files:
+        arrow = "▼ " if expanded else "▶ "
+    name = os.path.basename(queue_item.source_path)
+    return f"{order}. {arrow}{icon} {name}"
+
+
+def _renumber_queue_rows(gui) -> None:
+    """Rewrite the order-number prefix of every top-level row in place."""
+    for order, tree_id in enumerate(gui.queue_tree.get_children(), start=1):
+        queue_id = gui._tree_queue_map.get(tree_id)
+        queue_item = gui._queue_items_by_id.get(queue_id) if queue_id else None
+        if queue_item is None:
+            continue
+        expanded = _is_expanded(gui.queue_tree, tree_id)
+        gui.queue_tree.item(tree_id, text=_item_text(queue_item, order, expanded=expanded))
+
+
+def _display_context(gui) -> tuple[bool, object, dict, dict[str, TimeEstimate]]:
+    """Compute shared display inputs for row building.
+
+    Returns:
+        Tuple of (stopping, history index, percentiles by operation type,
+        pre-computed per-file time estimates).
+    """
+    # Check if stop has been requested (pending items won't run)
+    stopping = gui.session.running and gui.stop_event is not None and gui.stop_event.is_set()
+
+    index = get_history_index()
+
+    # Pre-compute percentiles once for all estimates (see TIME_ESTIMATION.md ## Performance)
+    percentiles_by_op = {
+        OperationType.CONVERT: compute_grouped_percentiles(OperationType.CONVERT),
+        OperationType.ANALYZE: compute_grouped_percentiles(OperationType.ANALYZE),
+    }
+
+    # Pre-compute time estimates for all nested files (avoids 3x calls per file)
+    file_estimates: dict[str, TimeEstimate] = {}
+    for queue_item in gui._queue_items:
+        if queue_item.is_folder and queue_item.files:
+            op_type = queue_item.operation_type
+            percentiles = percentiles_by_op.get(op_type)
+            for file_item in queue_item.files:
+                if file_item.path not in file_estimates:
+                    file_estimates[file_item.path] = estimate_file_time(
+                        file_item.path, operation_type=op_type, grouped_percentiles=percentiles
+                    )
+
+    return stopping, index, percentiles_by_op, file_estimates
+
+
+def _build_item_values(
+    gui, queue_item, stopping: bool, index, percentiles_by_op: dict, file_estimates: dict[str, TimeEstimate]
+) -> tuple[tuple, str]:
+    """Compute the values tuple and status tag for a top-level queue item row."""
+    # Get history record for metadata
+    path_hash = compute_path_hash(queue_item.source_path)
+    record = index.get(path_hash)
+
+    # Determine operation display based on operation type and Layer 2 data
+    operation_display = _format_operation_display(queue_item, record)
+
+    # Format output mode display
+    output_display = _format_output_display(queue_item, gui)
+
+    # Format codec/stream info
+    format_display = _format_format_display(queue_item, record)
+
+    # Format size - for folders, sum file sizes
+    size_display = _format_size_display(queue_item, record)
+
+    # Format estimated time
+    est_time_display = _format_time_estimate(queue_item, record, index, percentiles_by_op, file_estimates)
+
+    # Format status with tag
+    status_display, item_tag = format_queue_status_display(
+        queue_item.status,
+        stopping=stopping,
+        total_files=queue_item.total_files,
+        processed_files=queue_item.processed_files,
+    )
+    # Use the item's own format_status_display for non-stopping cases
+    if not stopping or queue_item.status != QueueItemStatus.PENDING:
+        if queue_item.status == QueueItemStatus.CONVERTING and queue_item.total_files > 0:
+            status_display = f"Converting ({queue_item.processed_files}/{queue_item.total_files})"
+        else:
+            status_display = queue_item.format_status_display()
+
+    values = (format_display, size_display, est_time_display, operation_display, output_display, status_display)
+    return values, item_tag
+
+
+def _build_file_values(
+    file_item, stopping: bool, index, file_estimates: dict[str, TimeEstimate]
+) -> tuple[tuple, str]:
+    """Compute the values tuple and status tag for a nested file row."""
+    file_size = format_file_size(file_item.size_bytes) if file_item.size_bytes > 0 else "—"
+
+    # Look up file record for format display
+    file_record = index.lookup_file(file_item.path)
+    if file_record and file_record.video_codec:
+        file_format = format_stream_display(file_record.video_codec, file_record.audio_streams)
+    else:
+        file_format = "—"
+
+    # Use pre-computed estimate from cache
+    file_time_estimate = file_estimates.get(file_item.path)
+    if file_time_estimate and file_time_estimate.confidence != "none" and file_time_estimate.best_seconds > 0:
+        file_est_time = format_compact_time(file_time_estimate.best_seconds, confidence=file_time_estimate.confidence)
+    else:
+        file_est_time = "—"
+
+    # Get status display and tag using shared function
+    file_status, file_tag = format_queue_file_status(
+        file_item.status,
+        stopping=stopping,
+        error_message=file_item.error_message,
+    )
+
+    return (file_format, file_size, file_est_time, "", "", file_status), file_tag
+
+
+def _update_folder_file_rows(
+    gui, queue_item, stopping: bool, index, file_estimates: dict[str, TimeEstimate]
+) -> None:
+    """Update nested file rows of a folder item in place (missing rows are skipped)."""
+    for file_item in queue_item.files:
+        file_tree_id = gui._queue_file_tree_map.get(file_item.path)
+        if not file_tree_id or not gui.queue_tree.exists(file_tree_id):
+            continue
+        values, file_tag = _build_file_values(file_item, stopping, index, file_estimates)
+        gui.queue_tree.item(file_tree_id, values=values, tags=(file_tag,))
+
+
+def _update_button_states(gui) -> None:
+    """Update queue-related button states after a tree change."""
+    update_clear_completed_button_state(gui)
+    update_remove_button_state(gui)
+    update_start_button_state(gui)
 
 
 def _format_format_display(queue_item, record) -> str:
@@ -278,37 +529,12 @@ def _insert_folder_file_rows(
     index = get_history_index()
 
     for file_item in queue_item.files:
-        file_name = os.path.basename(file_item.path)
-        file_size = format_file_size(file_item.size_bytes) if file_item.size_bytes > 0 else "—"
-
-        # Look up file record for format display
-        file_record = index.lookup_file(file_item.path)
-        if file_record and file_record.video_codec:
-            file_format = format_stream_display(file_record.video_codec, file_record.audio_streams)
-        else:
-            file_format = "—"
-
-        # Use pre-computed estimate from cache
-        file_time_estimate = file_estimates.get(file_item.path)
-        if file_time_estimate and file_time_estimate.confidence != "none" and file_time_estimate.best_seconds > 0:
-            file_est_time = format_compact_time(
-                file_time_estimate.best_seconds, confidence=file_time_estimate.confidence
-            )
-        else:
-            file_est_time = "—"
-
-        # Get status display and tag using shared function
-        file_status, file_tag = format_queue_file_status(
-            file_item.status,
-            stopping=stopping,
-            error_message=file_item.error_message,
-        )
-
+        values, file_tag = _build_file_values(file_item, stopping, index, file_estimates)
         file_tree_id = gui.queue_tree.insert(
             parent_item_id,
             "end",
-            text=f"    🎬 {file_name}",
-            values=(file_format, file_size, file_est_time, "", "", file_status),
+            text=f"    🎬 {os.path.basename(file_item.path)}",
+            values=values,
             tags=(file_tag,),
         )
         gui._queue_file_tree_map[file_item.path] = file_tree_id
@@ -375,7 +601,6 @@ def _update_total_row(
                 if confidence_order.get(file_estimate.confidence, 3) > confidence_order.get(lowest_confidence, 0):
                     lowest_confidence = file_estimate.confidence
         # else: folder without files populated - skip
-
     # Format displays
     total_size_display = format_file_size(total_size_bytes) if total_size_bytes > 0 else "—"
     if total_est_seconds > 0:

--- a/src/gui/tabs/convert_tab.py
+++ b/src/gui/tabs/convert_tab.py
@@ -305,6 +305,10 @@ def create_convert_tab(gui):
             queue_item.operation_type = new_operation
             gui.save_queue_to_config()
             gui.update_queue_item_row(queue_item)
+        elif selected_display == "Re-analyze + Convert":
+            # Type unchanged, but clearing Layer 2 data changes the displayed
+            # operation ("Convert" → "Analyze+Convert")
+            gui.update_queue_item_row(queue_item)
 
     def _show_context_menu(event):
         item_id = gui.queue_tree.identify_row(event.y)

--- a/src/gui/tabs/convert_tab.py
+++ b/src/gui/tabs/convert_tab.py
@@ -304,7 +304,7 @@ def create_convert_tab(gui):
         if queue_item.operation_type != new_operation:
             queue_item.operation_type = new_operation
             gui.save_queue_to_config()
-            gui.refresh_queue_tree()
+            gui.update_queue_item_row(queue_item)
 
     def _show_context_menu(event):
         item_id = gui.queue_tree.identify_row(event.y)

--- a/src/gui/widgets/operation_dropdown.py
+++ b/src/gui/widgets/operation_dropdown.py
@@ -179,7 +179,7 @@ class OperationDropdownManager:
         if queue_item.operation_type != new_operation:
             queue_item.operation_type = new_operation
             self._gui.save_queue_to_config()
-            self._gui.refresh_queue_tree()
+            self._gui.update_queue_item_row(queue_item)
 
     def _clear_layer2_data(self, source_path: str) -> None:
         """Clear cached CRF/VMAF data so file will be re-analyzed."""

--- a/src/gui/widgets/operation_dropdown.py
+++ b/src/gui/widgets/operation_dropdown.py
@@ -180,6 +180,10 @@ class OperationDropdownManager:
             queue_item.operation_type = new_operation
             self._gui.save_queue_to_config()
             self._gui.update_queue_item_row(queue_item)
+        elif selected == "Re-analyze + Convert":
+            # Type unchanged, but clearing Layer 2 data changes the displayed
+            # operation ("Convert" → "Analyze+Convert")
+            self._gui.update_queue_item_row(queue_item)
 
     def _clear_layer2_data(self, source_path: str) -> None:
         """Clear cached CRF/VMAF data so file will be re-analyzed."""


### PR DESCRIPTION
Queue tree folders no longer collapse when a file finishes processing, an item is added or removed, an operation type changes, or output settings change.

`refresh_queue_tree()` did a full delete-and-rebuild on every update, which reset every row to collapsed and also discarded selection and scroll position. The rebuild is now reserved for structural changes; everything else updates rows in place:

| Change | Function |
|--------|----------|
| Status, estimate, or output-setting changes (stop, force stop, queue complete, bulk suffix/folder edits) | `refresh_queue_tree_values()` recomputes values/tags of every row in place |
| Operation type change on one item | `update_queue_item_row()` |
| Items added | `add_queue_items_to_tree()` appends rows only |
| Selected items removed | `remove_queue_items_from_tree()` deletes those rows and renumbers the rest |
| Drag-drop reorder | order-number prefixes rewritten in place |

What is preserved: expand state, selection, and scroll position all survive on the incremental paths, since no rows are deleted. "Bulk" paths that restructure the tree (startup load, clear queue, clear completed, conflict replacement when re-adding with a different operation) keep the full rebuild, which now captures and restores folder expand state keyed by queue item id; selection and scroll still reset there.

Implementation notes for review:

- Row identity relies on the queue-item-id to tree-iid maps. The incremental functions now maintain all of them plus `_queue_items_by_id` (the append path previously depended on the full rebuild for that), and each function falls back to a full rebuild if the tree has drifted from `_queue_items`.
- The expand arrow lives in row text and is only swapped by user open/close events, so in-place value updates never touch text, and text rewrites (renumbering, rebuild restore) derive the arrow from the row's actual open state.
- The worker's status callback already updated in place; it is untouched, and the duplicate-skip statuses from #11 flow through it unchanged.
- The shared tag-handling extraction into `tree_utils.py` suggested in the issue is deferred: queue rows carry a single status tag, so the analysis tree's preserve-queue-tags-while-swapping-status-tags logic has no counterpart here yet, and there is no real duplication to extract.

Also fixed in passing (surfaced by review of this diff): selecting "Re-analyze + Convert" on an item already typed CONVERT cleared the cached CRF data but never refreshed the row, because the update was gated on the operation type changing. The row now refreshes so the operation column flips from "Convert" to "Analyze+Convert".

Verified with a throwaway Tk harness driving a real Treeview: expand state, iids, maps, renumbering, and the "Will skip" stopping display were asserted across value refreshes, single-item updates, appends, removals, reorders, and a rebuild.

Fixes #3
