### PR TITLE
chore: Bootstrap test suite, fix log-args privacy leak, config and doc hygiene

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,9 +75,10 @@ src/
     ├── charts.py              # Canvas-based chart drawing (bar, pie, line)
     ├── tabs/                  # Tab implementations
     │   ├── analysis_tab.py    # Analysis tab UI definition
-    │   ├── convert_tab.py     # Convert tab with queue and progress
+    │   ├── convert_tab.py     # Queue tab with queue and progress
+    │   ├── history_tab.py     # History tab: sortable/filterable list of processed files
     │   ├── settings_tab.py    # Settings tab
-    │   └── statistics_tab.py  # Statistics/history tab
+    │   └── statistics_tab.py  # Statistics tab: charts and summary metrics
     ├── dialogs/               # Modal dialog windows
     │   └── ffmpeg_download_dialog.py  # FFmpeg download confirmation
     └── widgets/               # Reusable UI components

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ uv run ruff check src/         # Lint
 uv run ruff check --fix src/   # Lint with auto-fix
 uv run ruff format src/        # Format
 uv run ty check src/           # Type check
+uv run pytest                  # Run unit tests
 ```
 
 ## Project Structure
@@ -204,7 +205,7 @@ AbAv1Wrapper.auto_encode()
 - Log caught exceptions with context - no silent swallowing
 - New constants go in `config.py`, not inline
 - Prefer creating focused modules over expanding large files
-- **No tests** - This project does not use automated testing
+- **Tests** - Unit tests live under `tests/` and run via `uv run pytest`. Changes to pure logic (parsing, formatting, cache/estimation math, etc.) should come with tests. GUI and worker code is exempt until the engine/GUI boundary refactor lands
 - **No time estimates** - Never provide effort/duration estimates for tasks
 
 ### Zero Backwards Compatibility Policy

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -156,6 +156,49 @@ Row identity is tracked by stable queue-item-id → tree-iid maps
 functions maintain these maps and fall back to a full rebuild if the tree
 has drifted from `_queue_items`.
 
+## History, Statistics, and Settings Tabs
+
+### History Tab
+
+The History tab (`gui/tabs/history_tab.py`) shows a flat list of files
+processed by ab-av1, loaded from `HistoryIndex.get_by_status()` for the
+CONVERTED, ANALYZED, and NOT_WORTHWHILE statuses. Filter checkboxes toggle
+each status and trigger a debounced (50 ms) refresh. The tab maintains its
+own tree state on the GUI object: `_history_tree_map` (path_hash → tree item
+id) plus sort state (`_history_sort_col`, `_history_sort_reverse`) — clicking
+a column header sorts in place with ▲/▼ indicators, parsing sizes, bitrates,
+percentages, and durations back to numbers for correct ordering.
+`compute_history_display_values()` formats every column for a record;
+output columns (output size, reduction, VMAF, CRF) are only populated for
+CONVERTED records. Right-click offers Open File / Show in Folder, suppressed
+for anonymized records with no `original_path`.
+
+### Statistics Tab
+
+The Statistics tab (`gui/tabs/statistics_tab.py`) aggregates CONVERTED
+records from `HistoryIndex.get_converted_records()` on the "Refresh
+Statistics" button. It renders three canvas charts from `gui/charts.py`:
+a size-reduction histogram (`BarChart`, 10% buckets), a source-codec
+`PieChart`, and a cumulative-space-saved-over-time `LineGraph`. A summary
+panel shows total files converted, average VMAF/CRF/size reduction (with
+min/max ranges), total space saved, throughput (GB of source video per
+hour), and the history date range.
+
+### Settings Tab
+
+The Settings tab (`gui/tabs/settings_tab.py`) is a form bound to Tkinter
+variables on the GUI object, persisted by `main_window.py`:
+
+- **Output Settings**: overwrite toggle, default output mode
+  (replace/suffix/separate_folder), default suffix and output folder
+- **Processing Options**: file extensions (MP4/MKV/AVI/WMV), audio
+  conversion codec (opus/aac), hardware-accelerated decoding toggle with
+  detected CUVID/QSV availability shown inline
+- **Logging & History**: log folder, anonymization toggles, and the
+  irreversible "Scrub Logs" / "Scrub History" actions
+- **Version Info**: app, ab-av1, and FFmpeg versions with Download /
+  Check for Updates buttons handled by `gui/dependency_manager.py`
+
 ## Threading Model
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,18 @@ build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [
+    "pytest>=9.1.1",
+    "pytest-cov>=7.1.0",
     "ruff",
     "ty",
 ]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"
 
 [tool.ruff]
 line-length = 120
@@ -109,6 +115,10 @@ ignore = [
 "__init__.py" = ["F401"]  # Allow unused imports in __init__.py
 "src/utils.py" = ["ERA001"]  # False positives: inline comments explaining regex patterns
 "src/gui/tabs/history_tab.py" = ["SLF001"]  # Authorized access to GUI._history_* internal state
+"tests/*" = [
+    "S101",     # assert is the pytest idiom
+    "PLR2004",  # magic values are expected in test assertions
+]
 
 [tool.ruff.lint.isort]
 split-on-trailing-comma = false

--- a/src/cache_helpers.py
+++ b/src/cache_helpers.py
@@ -9,13 +9,11 @@ avoiding redundant CRF searches.
 import logging
 import os
 
+from src.config import MTIME_TOLERANCE
 from src.history_index import compute_path_hash
 from src.models import FileRecord
 
 logger = logging.getLogger(__name__)
-
-# Tolerance for mtime comparison (1 second handles JSON float precision loss)
-MTIME_TOLERANCE = 1.0
 
 
 def mtimes_match(mtime1: float, mtime2: float) -> bool:

--- a/src/config.py
+++ b/src/config.py
@@ -28,6 +28,7 @@ def get_app_version() -> str:
         logger.warning(f"Could not read application version from {pyproject}; falling back to 'dev'", exc_info=True)
         return "dev"
 
+
 # --- Encoding Settings ---
 DEFAULT_VMAF_TARGET = 95  # Target VMAF score for quality-based encoding
 DEFAULT_ENCODING_PRESET = 6  # Corresponds to SVT-AV1 "--preset 6" (Balanced speed/quality)
@@ -41,9 +42,9 @@ VMAF_FALLBACK_STEP = 1  # How much to decrement VMAF target on each fallback att
 # Format: (max_duration_minutes, log_interval) - uses first matching tier
 # Set to None to disable (falls back to ab-av1's exponential backoff)
 LOG_INTERVAL_TIERS: list[tuple[int | None, str]] = [
-    (30, "5%"),    # < 30 min: every 5% (~20 updates)
-    (120, "2%"),   # 30 min - 2 hr: every 2% (~50 updates)
-    (240, "1%"),   # 2 - 4 hr: every 1% (~100 updates)
+    (30, "5%"),  # < 30 min: every 5% (~20 updates)
+    (120, "2%"),  # 30 min - 2 hr: every 2% (~50 updates)
+    (240, "1%"),  # 2 - 4 hr: every 1% (~100 updates)
     (None, "1%"),  # > 4 hr: every 1% (~100 updates)
 ]
 

--- a/src/config.py
+++ b/src/config.py
@@ -121,33 +121,6 @@ MTIME_TOLERANCE = 1.0
 # --- Tree Display Formatting ---
 EFFICIENCY_DECIMAL_THRESHOLD = 10  # Show GB/hr without decimals above this value
 
-# Analysis tree column headings (base text without sort indicators)
-ANALYSIS_TREE_HEADINGS: dict[str, str] = {
-    "#0": "Name",
-    "format": "Format",
-    "size": "Size",
-    "savings": "Est. Savings",
-    "time": "Est. Time",
-    "efficiency": "Efficiency",
-}
-
-# History tree column headings
-HISTORY_TREE_HEADINGS: dict[str, str] = {
-    "date": "Date",
-    "#0": "Name",
-    "status": "Status",
-    "resolution": "Resolution",
-    "codec": "Codec",
-    "bitrate": "Bitrate",
-    "duration": "Duration",
-    "audio": "Audio",
-    "input_size": "Input",
-    "output_size": "Output",
-    "reduction": "Reduction",
-    "vmaf": "VMAF",
-    "crf": "CRF",
-}
-
 # --- Hardware Decoder Settings ---
 # Hardware decoder mapping (source codec -> preferred decoders in priority order)
 HW_DECODER_MAP: dict[str, list[str]] = {

--- a/src/config.py
+++ b/src/config.py
@@ -115,6 +115,9 @@ RESOLUTION_TOLERANCE_PERCENT = 0.2  # Tolerance for resolution matching (20%)
 # A tolerance of 0.1 safely covers rounding while avoiding false positives on different files.
 DURATION_TOLERANCE_SEC = 0.1
 
+# Tolerance for mtime comparison (1 second handles JSON float precision loss)
+MTIME_TOLERANCE = 1.0
+
 # --- Tree Display Formatting ---
 EFFICIENCY_DECIMAL_THRESHOLD = 10  # Show GB/hr without decimals above this value
 

--- a/src/config.py
+++ b/src/config.py
@@ -3,18 +3,30 @@
 Central configuration constants for the AV1 Video Converter application.
 """
 
+import functools
+import logging
+import tomllib
+from pathlib import Path
 from typing import TypedDict
 
-# --- Application Version ---
-try:
-    import tomllib
-    from pathlib import Path
+logger = logging.getLogger(__name__)
 
-    _pyproject = Path(__file__).parent.parent / "pyproject.toml"
-    with open(_pyproject, "rb") as _f:
-        APP_VERSION = tomllib.load(_f)["project"]["version"]
-except Exception:
-    APP_VERSION = "dev"
+
+# --- Application Version ---
+@functools.cache
+def get_app_version() -> str:
+    """Read the application version from pyproject.toml.
+
+    Returns:
+        The version string, or "dev" if pyproject.toml cannot be read.
+    """
+    pyproject = Path(__file__).parent.parent / "pyproject.toml"
+    try:
+        with open(pyproject, "rb") as f:
+            return tomllib.load(f)["project"]["version"]
+    except Exception:
+        logger.warning(f"Could not read application version from {pyproject}; falling back to 'dev'", exc_info=True)
+        return "dev"
 
 # --- Encoding Settings ---
 DEFAULT_VMAF_TARGET = 95  # Target VMAF score for quality-based encoding

--- a/src/gui/analysis_controller.py
+++ b/src/gui/analysis_controller.py
@@ -160,8 +160,7 @@ def prune_empty_folders(gui) -> int:
                 if "📁" in text:
                     gui.analysis_tree.delete(item_id)
                     # Clean up cached folder aggregates
-                    if hasattr(gui, "folder_aggregates"):
-                        gui.folder_aggregates.pop(item_id, None)
+                    gui.folder_aggregates.pop(item_id, None)
                     removed_this_pass += 1
 
         total_removed += removed_this_pass
@@ -628,6 +627,5 @@ def clear_analysis_tree(gui) -> None:
     for item in gui.analysis_tree.get_children():
         gui.analysis_tree.delete(item)
     gui._tree_item_map.clear()
-    if hasattr(gui, "folder_aggregates"):
-        gui.folder_aggregates.clear()
+    gui.folder_aggregates.clear()
     clear_sort_state(gui)

--- a/src/gui/analysis_tree.py
+++ b/src/gui/analysis_tree.py
@@ -146,11 +146,7 @@ def batch_update_tree_rows(gui, file_paths: list[str]) -> None:
 
 
 def update_folder_aggregates(
-    gui,
-    folder_id: str,
-    item_to_path: dict[str, str] | None = None,
-    *,
-    grouped_percentiles: dict | None = None,
+    gui, folder_id: str, item_to_path: dict[str, str] | None = None, *, grouped_percentiles: dict | None = None
 ):
     """Recalculate and update folder aggregate values.
 
@@ -277,11 +273,7 @@ def get_queued_file_paths(gui) -> set[str]:
     return queued_paths
 
 
-def sync_queue_tags_to_analysis_tree(
-    gui,
-    added_paths: set[str] | None = None,
-    removed_paths: set[str] | None = None,
-):
+def sync_queue_tags_to_analysis_tree(gui, added_paths: set[str] | None = None, removed_paths: set[str] | None = None):
     """Synchronize queue status to analysis tree item tags.
 
     Applies 'in_queue' tag to files in the queue, 'partial_queue' to folders

--- a/src/gui/analysis_tree.py
+++ b/src/gui/analysis_tree.py
@@ -219,7 +219,7 @@ def update_folder_aggregates(
                 total_time += file_time
         else:
             # Child is a subfolder - read its cached aggregates
-            folder_agg = getattr(gui, "folder_aggregates", {}).get(child_id)
+            folder_agg = gui.folder_aggregates.get(child_id)
             if folder_agg:
                 child_size, child_savings, child_time, child_any_estimate = folder_agg
                 total_size += child_size
@@ -241,8 +241,6 @@ def update_folder_aggregates(
     gui.analysis_tree.item(folder_id, values=("", size_str, savings_str, time_str, eff_str))
 
     # Cache this folder's aggregates for parent folder calculations
-    if not hasattr(gui, "folder_aggregates"):
-        gui.folder_aggregates = {}
     gui.folder_aggregates[folder_id] = (total_size, total_savings, total_time, any_estimate)
 
 

--- a/src/gui/constants.py
+++ b/src/gui/constants.py
@@ -135,6 +135,36 @@ TOOLTIP_TIME_COLUMN = (
 )
 
 # =============================================================================
+# TREE COLUMN HEADINGS
+# =============================================================================
+# Analysis tree column headings (base text without sort indicators)
+ANALYSIS_TREE_HEADINGS: dict[str, str] = {
+    "#0": "Name",
+    "format": "Format",
+    "size": "Size",
+    "savings": "Est. Savings",
+    "time": "Est. Time",
+    "efficiency": "Efficiency",
+}
+
+# History tree column headings
+HISTORY_TREE_HEADINGS: dict[str, str] = {
+    "date": "Date",
+    "#0": "Name",
+    "status": "Status",
+    "resolution": "Resolution",
+    "codec": "Codec",
+    "bitrate": "Bitrate",
+    "duration": "Duration",
+    "audio": "Audio",
+    "input_size": "Input",
+    "output_size": "Output",
+    "reduction": "Reduction",
+    "vmaf": "VMAF",
+    "crf": "CRF",
+}
+
+# =============================================================================
 # OUTPUT MODE - Display Labels
 # =============================================================================
 # Mapping between human-readable display strings and internal enum values.

--- a/src/gui/dependency_manager.py
+++ b/src/gui/dependency_manager.py
@@ -14,7 +14,7 @@ from tkinter import ttk
 from typing import TYPE_CHECKING
 
 from src.ab_av1.checker import check_ab_av1_latest_github, check_app_latest_github, get_ab_av1_version
-from src.config import APP_VERSION
+from src.config import get_app_version
 from src.gui.constants import (
     COLOR_STATUS_ERROR,
     COLOR_STATUS_INFO,
@@ -64,8 +64,10 @@ def check_app_updates(gui: "VideoConverterGUI") -> None:
         gui.app_update_label.config(text=message, foreground=COLOR_STATUS_ERROR)
         return
 
+    app_version = get_app_version()
+
     # For "dev" version, just show latest without comparison
-    if APP_VERSION == "dev":
+    if app_version == "dev":
         gui.app_update_label.config(
             text=f"Latest: {latest_version}", foreground=COLOR_STATUS_INFO, cursor="hand2", font=FONT_SYSTEM_UNDERLINE
         )
@@ -78,15 +80,15 @@ def check_app_updates(gui: "VideoConverterGUI") -> None:
         return tuple(int(x) for x in v.split("."))
 
     try:
-        local_parts = parse_semver(APP_VERSION)
+        local_parts = parse_semver(app_version)
         latest_parts = parse_semver(latest_version)
         is_up_to_date = local_parts >= latest_parts
     except ValueError:
         # Fallback to string comparison if parsing fails
-        is_up_to_date = latest_version == APP_VERSION
+        is_up_to_date = latest_version == app_version
 
     if is_up_to_date:
-        gui.app_update_label.config(text=f"Up to date ({APP_VERSION})", foreground=COLOR_STATUS_SUCCESS)
+        gui.app_update_label.config(text=f"Up to date ({app_version})", foreground=COLOR_STATUS_SUCCESS)
     else:
         # Update available - make label clickable
         gui.app_update_label.config(

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -789,9 +789,7 @@ class VideoConverterGUI:
         return analysis_tree.get_queued_file_paths(self)
 
     def sync_queue_tags_to_analysis_tree(
-        self,
-        added_paths: set[str] | None = None,
-        removed_paths: set[str] | None = None,
+        self, added_paths: set[str] | None = None, removed_paths: set[str] | None = None
     ):
         return analysis_tree.sync_queue_tags_to_analysis_tree(self, added_paths, removed_paths)
 

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -382,6 +382,8 @@ class VideoConverterGUI:
         self.analysis_stop_event: threading.Event | None = None
         self.analysis_thread: threading.Thread | None = None
         self._tree_item_map: dict[str, str] = {}  # Map file_path -> tree_item_id for updates
+        # Cached folder aggregates: folder tree_item_id -> (total_size, total_savings, total_time, any_estimate)
+        self.folder_aggregates: dict[str, tuple[int, int, float, bool]] = {}
         self._refresh_timer_id: str | None = None  # Debounce timer for auto-refresh
         self._scan_stop_event: threading.Event | None = None  # Stop event for background scan
         self._scanning: bool = False  # True while background scan is running

--- a/src/gui/tabs/analysis_tab.py
+++ b/src/gui/tabs/analysis_tab.py
@@ -11,9 +11,9 @@ import os
 import tkinter as tk
 from tkinter import ttk
 
-from src.config import ANALYSIS_TREE_HEADINGS
 from src.gui.base import ToolTip, TreeviewHeaderTooltip, TreeviewRowTooltip, open_in_explorer, reveal_in_explorer
 from src.gui.constants import (
+    ANALYSIS_TREE_HEADINGS,
     COLOR_BADGE_BACKGROUND,
     COLOR_BADGE_TEXT,
     COLOR_STATUS_DISABLED,

--- a/src/gui/tabs/analysis_tab.py
+++ b/src/gui/tabs/analysis_tab.py
@@ -288,15 +288,18 @@ def create_analysis_tab(gui):
     TreeviewRowTooltip(gui.analysis_tree, gui.get_analysis_tree_tooltip)
 
     # Set up column header tooltips
-    TreeviewHeaderTooltip(gui.analysis_tree, {
-        "savings": (
-            "Estimated space saved after conversion.\n"
-            "'~' prefix = estimate from similar files.\n"
-            "No prefix = precise prediction from CRF analysis."
-        ),
-        "time": TOOLTIP_TIME_COLUMN,
-        "efficiency": "GB saved per hour of conversion time.\nHigher = more space savings for your time.",
-    })
+    TreeviewHeaderTooltip(
+        gui.analysis_tree,
+        {
+            "savings": (
+                "Estimated space saved after conversion.\n"
+                "'~' prefix = estimate from similar files.\n"
+                "No prefix = precise prediction from CRF analysis."
+            ),
+            "time": TOOLTIP_TIME_COLUMN,
+            "efficiency": "GB saved per hour of conversion time.\nHigher = more space savings for your time.",
+        },
+    )
 
     # --- Row 2: Fixed total row (non-scrolling, always visible) ---
     # Use a separate single-row Treeview with matching columns for perfect alignment

--- a/src/gui/tabs/history_tab.py
+++ b/src/gui/tabs/history_tab.py
@@ -17,9 +17,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from src.gui.main_window import VideoConverterGUI
 
-from src.config import HISTORY_TREE_HEADINGS
 from src.gui.base import ToolTip, TreeviewHeaderTooltip
-from src.gui.constants import COLOR_STATUS_SUCCESS, COLOR_STATUS_WARNING
+from src.gui.constants import COLOR_STATUS_SUCCESS, COLOR_STATUS_WARNING, HISTORY_TREE_HEADINGS
 from src.history_index import get_history_index
 from src.models import FileRecord, FileStatus
 from src.utils import format_file_size, format_time

--- a/src/gui/tabs/history_tab.py
+++ b/src/gui/tabs/history_tab.py
@@ -60,28 +60,19 @@ def create_history_tab(gui: "VideoConverterGUI") -> None:
     ttk.Label(controls_frame, text="Show:").pack(side="left", padx=(0, 5))
 
     converted_cb = ttk.Checkbutton(
-        controls_frame,
-        text="Converted",
-        variable=gui.history_show_converted,
-        command=lambda: _on_filter_changed(gui),
+        controls_frame, text="Converted", variable=gui.history_show_converted, command=lambda: _on_filter_changed(gui)
     )
     converted_cb.pack(side="left", padx=(0, 10))
     ToolTip(converted_cb, "Files fully encoded to AV1")
 
     analyzed_cb = ttk.Checkbutton(
-        controls_frame,
-        text="Analyzed",
-        variable=gui.history_show_analyzed,
-        command=lambda: _on_filter_changed(gui),
+        controls_frame, text="Analyzed", variable=gui.history_show_analyzed, command=lambda: _on_filter_changed(gui)
     )
     analyzed_cb.pack(side="left", padx=(0, 10))
     ToolTip(analyzed_cb, "Files analyzed for optimal CRF but not yet encoded")
 
     skipped_cb = ttk.Checkbutton(
-        controls_frame,
-        text="Skipped",
-        variable=gui.history_show_skipped,
-        command=lambda: _on_filter_changed(gui),
+        controls_frame, text="Skipped", variable=gui.history_show_skipped, command=lambda: _on_filter_changed(gui)
     )
     skipped_cb.pack(side="left", padx=(0, 10))
     ToolTip(skipped_cb, "Files skipped (already AV1, or no worthwhile savings)")
@@ -112,12 +103,7 @@ def create_history_tab(gui: "VideoConverterGUI") -> None:
         "crf",
     )
 
-    gui.history_tree = ttk.Treeview(
-        tree_frame,
-        columns=columns,
-        show="tree headings",
-        selectmode="extended",
-    )
+    gui.history_tree = ttk.Treeview(tree_frame, columns=columns, show="tree headings", selectmode="extended")
 
     # Configure columns
     gui.history_tree.column("#0", width=COLUMN_WIDTHS["#0"], minwidth=80, stretch=True)
@@ -130,9 +116,7 @@ def create_history_tab(gui: "VideoConverterGUI") -> None:
             anchor = "w"
         gui.history_tree.column(col, width=width, minwidth=width, stretch=False, anchor=anchor)
         gui.history_tree.heading(
-            col,
-            text=HISTORY_TREE_HEADINGS.get(col, col.title()),
-            command=lambda c=col: sort_history_tree(gui, c),
+            col, text=HISTORY_TREE_HEADINGS.get(col, col.title()), command=lambda c=col: sort_history_tree(gui, c)
         )
 
     # Configure tags for status coloring
@@ -140,12 +124,15 @@ def create_history_tab(gui: "VideoConverterGUI") -> None:
     gui.history_tree.tag_configure("skip", foreground=COLOR_STATUS_WARNING)
 
     # Set up column header tooltips
-    TreeviewHeaderTooltip(gui.history_tree, {
-        "bitrate": "Source video bitrate.\nHigher usually means higher quality source.",
-        "reduction": "Percentage of original file size saved.\nHigher = more space saved.",
-        "vmaf": "Quality score achieved (0-100).\n95+ is visually lossless.",
-        "crf": "Compression level used (0-63).\nLower = higher quality.",
-    })
+    TreeviewHeaderTooltip(
+        gui.history_tree,
+        {
+            "bitrate": "Source video bitrate.\nHigher usually means higher quality source.",
+            "reduction": "Percentage of original file size saved.\nHigher = more space saved.",
+            "vmaf": "Quality score achieved (0-100).\n95+ is visually lossless.",
+            "crf": "Compression level used (0-63).\nLower = higher quality.",
+        },
+    )
 
     # Scrollbar
     scrollbar = ttk.Scrollbar(tree_frame, orient="vertical", command=gui.history_tree.yview)
@@ -220,13 +207,7 @@ def populate_history_tree(gui: "VideoConverterGUI", records: list[FileRecord]) -
         values = compute_history_display_values(record)
         tag = get_history_status_tag(record.status)
 
-        item_id = gui.history_tree.insert(
-            "",
-            "end",
-            text=name,
-            values=values,
-            tags=(tag,) if tag else (),
-        )
+        item_id = gui.history_tree.insert("", "end", text=name, values=values, tags=(tag,) if tag else ())
         gui._history_tree_map[record.path_hash] = item_id
 
 
@@ -300,8 +281,18 @@ def compute_history_display_values(record: FileRecord) -> tuple[str, ...]:
         crf = "—"
 
     return (
-        date_str, status, resolution, codec, bitrate, duration,
-        audio, input_size, output_size, reduction, vmaf, crf,
+        date_str,
+        status,
+        resolution,
+        codec,
+        bitrate,
+        duration,
+        audio,
+        input_size,
+        output_size,
+        reduction,
+        vmaf,
+        crf,
     )
 
 
@@ -465,8 +456,19 @@ def _parse_duration(val: str) -> float:
 def _update_sort_indicators(gui: "VideoConverterGUI") -> None:
     """Update column headers to show sort direction."""
     all_columns = [
-        "#0", "date", "status", "resolution", "codec", "bitrate",
-        "duration", "audio", "input_size", "output_size", "reduction", "vmaf", "crf",
+        "#0",
+        "date",
+        "status",
+        "resolution",
+        "codec",
+        "bitrate",
+        "duration",
+        "audio",
+        "input_size",
+        "output_size",
+        "reduction",
+        "vmaf",
+        "crf",
     ]
     for col in all_columns:
         base_text = HISTORY_TREE_HEADINGS.get(col, col.title())

--- a/src/gui/tabs/settings_tab.py
+++ b/src/gui/tabs/settings_tab.py
@@ -58,9 +58,9 @@ def create_settings_tab(gui):
     suffix_row.grid(row=2, column=1, columnspan=2, sticky="w", padx=5, pady=3)
     suffix_entry = ttk.Entry(suffix_row, textvariable=gui.default_suffix, width=15)
     suffix_entry.pack(side="left")
-    ttk.Label(
-        suffix_row, text="e.g. '_av1' → video_av1.mkv", foreground=COLOR_TEXT_MUTED
-    ).pack(side="left", padx=(10, 0))
+    ttk.Label(suffix_row, text="e.g. '_av1' → video_av1.mkv", foreground=COLOR_TEXT_MUTED).pack(
+        side="left", padx=(10, 0)
+    )
 
     # Default Output Folder (for separate_folder mode)
     ttk.Label(output_frame, text="Default Output Folder:").grid(row=3, column=0, sticky="w", padx=10, pady=(3, 5))
@@ -119,9 +119,9 @@ def create_settings_tab(gui):
     audio_combo = ttk.Combobox(audio_frame, textvariable=gui.audio_codec, width=10, state="readonly")
     audio_combo["values"] = ("opus", "aac")
     audio_combo.pack(side="left")
-    ttk.Label(
-        audio_frame, text="(opus = smaller, aac = compatible)", foreground=COLOR_TEXT_MUTED
-    ).pack(side="left", padx=(10, 0))
+    ttk.Label(audio_frame, text="(opus = smaller, aac = compatible)", foreground=COLOR_TEXT_MUTED).pack(
+        side="left", padx=(10, 0)
+    )
 
     # Hardware decoding (moved from separate Hardware Acceleration frame)
     hw_decode_row = ttk.Frame(processing_frame)
@@ -211,9 +211,7 @@ def create_settings_tab(gui):
 
     scrub_history_btn = ttk.Button(history_actions_frame, text="Scrub History", command=gui.on_scrub_history)
     scrub_history_btn.pack(side="left")
-    ttk.Label(
-        history_actions_frame, text="(irreversible)", foreground=COLOR_TEXT_MUTED
-    ).pack(side="left", padx=(5, 0))
+    ttk.Label(history_actions_frame, text="(irreversible)", foreground=COLOR_TEXT_MUTED).pack(side="left", padx=(5, 0))
 
     # --- Version Info ---
     version_frame = ttk.LabelFrame(settings_frame, text="Version Info")

--- a/src/gui/tabs/settings_tab.py
+++ b/src/gui/tabs/settings_tab.py
@@ -7,7 +7,7 @@ import logging
 from tkinter import ttk
 
 from src.ab_av1.checker import get_ab_av1_version
-from src.config import APP_VERSION
+from src.config import get_app_version
 from src.gui.base import ToolTip
 from src.gui.constants import COLOR_STATUS_NEUTRAL, COLOR_STATUS_SUCCESS_LIGHT, COLOR_TEXT_MUTED, FONT_SYSTEM_BOLD
 from src.hardware_accel import get_available_hw_decoders
@@ -224,12 +224,13 @@ def create_settings_tab(gui):
     app_frame.grid(row=0, column=0, sticky="w", padx=10, pady=(5, 3))
     gui.app_frame = app_frame
 
+    app_version = get_app_version()
     ttk.Label(app_frame, text="AB-AV1-GUI Version:").pack(side="left", padx=(0, 5))
-    gui.app_version_label = ttk.Label(app_frame, text=APP_VERSION, font=FONT_SYSTEM_BOLD)
+    gui.app_version_label = ttk.Label(app_frame, text=app_version, font=FONT_SYSTEM_BOLD)
     gui.app_version_label.pack(side="left", padx=(0, 15))
 
     # Show Check for Updates button (hide for dev builds since we can't compare)
-    if APP_VERSION != "dev":
+    if app_version != "dev":
         gui.app_check_btn = ttk.Button(app_frame, text="Check for Updates", command=gui.on_check_app_updates)
         gui.app_check_btn.pack(side="left", padx=(0, 10))
         ToolTip(

--- a/src/gui/tree_formatters.py
+++ b/src/gui/tree_formatters.py
@@ -7,7 +7,8 @@ display strings and parsing those strings back for sorting/comparison.
 
 import logging
 
-from src.config import ANALYSIS_TREE_HEADINGS, EFFICIENCY_DECIMAL_THRESHOLD
+from src.config import EFFICIENCY_DECIMAL_THRESHOLD
+from src.gui.constants import ANALYSIS_TREE_HEADINGS
 
 logger = logging.getLogger(__name__)
 

--- a/src/main.py
+++ b/src/main.py
@@ -48,11 +48,8 @@ def main():
     app = None  # Initialize app
 
     try:
-        # Create the application instance
+        # Create the application instance (registers WM_DELETE_WINDOW itself)
         app = VideoConverterGUI(root)
-
-        # Register window protocol for proper cleanup
-        root.protocol("WM_DELETE_WINDOW", app.on_exit)
 
         # Start the Tkinter main event loop
         logger.info("Starting Tkinter main loop...")

--- a/src/privacy.py
+++ b/src/privacy.py
@@ -220,9 +220,20 @@ class PathPrivacyFilter(logging.Filter):
     """
 
     def filter(self, record: logging.LogRecord) -> bool:
-        if hasattr(record, "msg") and isinstance(record.msg, str):
-            temp_msg = record.msg
-            for pattern in PATH_PATTERNS:
-                temp_msg = pattern.sub(_anonymize_path_match, temp_msg)
-            record.msg = temp_msg
+        try:
+            if record.args:
+                # Collapse %-style args into the message so paths passed as
+                # args are scrubbed too (they'd otherwise bypass the patterns)
+                record.msg = record.getMessage()
+                record.args = ()
+            if hasattr(record, "msg") and isinstance(record.msg, str):
+                temp_msg = record.msg
+                for pattern in PATH_PATTERNS:
+                    temp_msg = pattern.sub(_anonymize_path_match, temp_msg)
+                record.msg = temp_msg
+        except Exception:
+            # A logging failure must never break the app; the record passes
+            # through unmodified (formatting of a malformed record will be
+            # handled by logging's own error handling downstream)
+            logger.exception("PathPrivacyFilter failed to anonymize log record")
         return True

--- a/tests/test_cache_helpers.py
+++ b/tests/test_cache_helpers.py
@@ -1,0 +1,140 @@
+# tests/test_cache_helpers.py
+"""Characterization tests for src/cache_helpers.py cache validation logic."""
+
+import os
+
+from src.cache_helpers import converted_verdict_applies, is_file_unchanged
+from src.history_index import compute_path_hash
+from src.models import FileRecord, FileStatus
+
+
+def make_record(file_path: str, *, status: FileStatus = FileStatus.CONVERTED, **overrides) -> FileRecord:
+    """Build a FileRecord whose stamps match the file currently on disk."""
+    stat_info = os.stat(file_path)
+    fields = {
+        "path_hash": compute_path_hash(file_path),
+        "original_path": file_path,
+        "status": status,
+        "file_size_bytes": stat_info.st_size,
+        "file_mtime": stat_info.st_mtime,
+    }
+    fields.update(overrides)
+    return FileRecord(**fields)
+
+
+def write_file(path, content: bytes = b"video-bytes") -> str:
+    path.write_bytes(content)
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
+# is_file_unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_unchanged_file_matches(tmp_path):
+    file_path = write_file(tmp_path / "movie.mp4")
+    record = make_record(file_path)
+
+    assert is_file_unchanged(record, file_path) is True
+
+
+def test_mtime_within_tolerance_still_matches(tmp_path):
+    # JSON round-trips lose float precision; anything under 1s counts as equal.
+    file_path = write_file(tmp_path / "movie.mp4")
+    record = make_record(file_path)
+    record.file_mtime = os.stat(file_path).st_mtime + 0.5
+
+    assert is_file_unchanged(record, file_path) is True
+
+
+def test_mtime_beyond_tolerance_does_not_match(tmp_path):
+    file_path = write_file(tmp_path / "movie.mp4")
+    record = make_record(file_path)
+    record.file_mtime = os.stat(file_path).st_mtime + 1.5
+
+    assert is_file_unchanged(record, file_path) is False
+
+
+def test_size_mismatch_does_not_match(tmp_path):
+    file_path = write_file(tmp_path / "movie.mp4")
+    record = make_record(file_path, file_size_bytes=os.stat(file_path).st_size + 1)
+
+    assert is_file_unchanged(record, file_path) is False
+
+
+def test_path_hash_mismatch_does_not_match(tmp_path):
+    file_path = write_file(tmp_path / "movie.mp4")
+    record = make_record(file_path, path_hash=compute_path_hash("/somewhere/else.mp4"))
+
+    assert is_file_unchanged(record, file_path) is False
+
+
+def test_missing_file_does_not_match(tmp_path):
+    file_path = write_file(tmp_path / "movie.mp4")
+    record = make_record(file_path)
+    missing = str(tmp_path / "gone.mp4")
+    record.path_hash = compute_path_hash(missing)
+
+    assert is_file_unchanged(record, missing) is False
+
+
+# ---------------------------------------------------------------------------
+# converted_verdict_applies
+# ---------------------------------------------------------------------------
+
+
+def test_verdict_applies_when_file_unchanged(tmp_path):
+    file_path = write_file(tmp_path / "movie.mp4")
+    record = make_record(file_path, output_size_bytes=5)
+
+    assert converted_verdict_applies(record, file_path) is True
+
+
+def test_legacy_record_without_output_size_keeps_verdict(tmp_path):
+    # Legacy path: no Layer-3 output size means we can't tell our own output
+    # apart from genuinely changed content, so the verdict is kept.
+    file_path = write_file(tmp_path / "movie.mkv")
+    record = make_record(file_path, output_size_bytes=None)
+    (tmp_path / "movie.mkv").write_bytes(b"completely different content!!")
+
+    assert converted_verdict_applies(record, file_path) is True
+
+
+def test_changed_non_mkv_file_invalidates_verdict(tmp_path):
+    file_path = write_file(tmp_path / "movie.mp4")
+    record = make_record(file_path, output_size_bytes=999)
+    (tmp_path / "movie.mp4").write_bytes(b"new content of a different size")
+
+    assert converted_verdict_applies(record, file_path) is False
+
+
+def test_replace_mode_output_recognized_by_size(tmp_path):
+    # Replace-mode steady state: the .mkv at the input path IS our output.
+    # Stamps differ from the recorded input, but the size equals the recorded
+    # output size, so the verdict still applies.
+    output_content = b"x" * 100
+    file_path = write_file(tmp_path / "movie.mkv", b"y" * 50)
+    record = make_record(file_path, output_size_bytes=100)
+    (tmp_path / "movie.mkv").write_bytes(output_content)
+
+    assert converted_verdict_applies(record, file_path) is True
+
+
+def test_changed_mkv_with_size_mismatch_invalidates_verdict(tmp_path):
+    file_path = write_file(tmp_path / "movie.mkv", b"y" * 50)
+    record = make_record(file_path, output_size_bytes=100)
+    (tmp_path / "movie.mkv").write_bytes(b"z" * 77)
+
+    assert converted_verdict_applies(record, file_path) is False
+
+
+def test_missing_mkv_keeps_verdict_conservatively(tmp_path):
+    # getsize() fails on a vanished file: current behavior keeps the verdict
+    # rather than re-queueing.
+    file_path = write_file(tmp_path / "movie.mkv")
+    record = make_record(file_path, output_size_bytes=100)
+    missing = str(tmp_path / "gone.mkv")
+    record.path_hash = compute_path_hash(missing)
+
+    assert converted_verdict_applies(record, missing) is True

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -1,0 +1,169 @@
+# tests/test_estimation.py
+"""Characterization tests for the pure math in src/estimation.py.
+
+Functions needing get_history_index() or a gui object (compute_grouped_*,
+estimate_pending_files_eta, estimate_remaining_time) are not covered;
+estimate_file_time is exercised only with explicit metadata and pre-computed
+percentiles so the history index is never touched.
+"""
+
+import time
+
+from src.estimation import compute_percentiles, estimate_current_file_eta, estimate_file_time, get_resolution_bucket
+
+# ---------------------------------------------------------------------------
+# get_resolution_bucket
+# ---------------------------------------------------------------------------
+
+
+def test_resolution_buckets_standard_sizes():
+    assert get_resolution_bucket(3840, 2160) == "4k"
+    assert get_resolution_bucket(2560, 1440) == "1440p"
+    assert get_resolution_bucket(1920, 1080) == "1080p"
+    assert get_resolution_bucket(1280, 720) == "720p"
+    assert get_resolution_bucket(720, 480) == "sd"
+
+
+def test_resolution_bucket_uses_pixel_count_not_orientation():
+    # Portrait video with the same pixel count lands in the same bucket.
+    assert get_resolution_bucket(1080, 1920) == "1080p"
+
+
+def test_resolution_bucket_boundary_just_below_720p_is_sd():
+    assert get_resolution_bucket(1279, 720) == "sd"
+
+
+def test_resolution_bucket_missing_dimensions():
+    assert get_resolution_bucket(None, 1080) == "unknown"
+    assert get_resolution_bucket(1920, None) == "unknown"
+    assert get_resolution_bucket(0, 0) == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# compute_percentiles
+# ---------------------------------------------------------------------------
+
+
+def test_compute_percentiles_requires_minimum_samples():
+    assert compute_percentiles([]) is None
+    assert compute_percentiles([1.0, 2.0, 3.0, 4.0]) is None  # MIN_SAMPLES_FOR_ESTIMATE = 5
+
+
+def test_compute_percentiles_quartiles():
+    result = compute_percentiles([1.0, 2.0, 3.0, 4.0, 5.0])
+    assert result == {"p25": 1.5, "p50": 3.0, "p75": 4.5, "count": 5}
+
+
+# ---------------------------------------------------------------------------
+# estimate_file_time (tiered lookup with pre-computed percentiles)
+# ---------------------------------------------------------------------------
+
+STATS_10 = {"p25": 1.0, "p50": 2.0, "p75": 3.0, "count": 10}
+STATS_5 = {"p25": 1.0, "p50": 2.0, "p75": 3.0, "count": 5}
+
+
+def test_tier1_codec_and_resolution_high_confidence():
+    estimate = estimate_file_time(
+        codec="h264", duration=600.0, width=1920, height=1080, grouped_percentiles={("h264", "1080p"): STATS_10}
+    )
+    assert estimate.confidence == "high"
+    assert estimate.source == "h264:1080p"
+    assert estimate.min_seconds == 600.0
+    assert estimate.best_seconds == 1200.0
+    assert estimate.max_seconds == 1800.0
+
+
+def test_tier1_medium_confidence_below_10_samples():
+    estimate = estimate_file_time(
+        codec="h264", duration=600.0, width=1920, height=1080, grouped_percentiles={("h264", "1080p"): STATS_5}
+    )
+    assert estimate.confidence == "medium"
+    assert estimate.source == "h264:1080p"
+
+
+def test_tier2_codec_only_fallback():
+    estimate = estimate_file_time(
+        codec="h264", duration=600.0, width=1920, height=1080, grouped_percentiles={("h264", None): STATS_10}
+    )
+    assert estimate.confidence == "medium"
+    assert estimate.source == "codec:h264"
+    assert estimate.best_seconds == 1200.0
+
+
+def test_tier3_global_fallback():
+    estimate = estimate_file_time(
+        codec="h264", duration=600.0, width=1920, height=1080, grouped_percentiles={(None, None): STATS_10}
+    )
+    assert estimate.confidence == "low"
+    assert estimate.source == "global"
+
+
+def test_tier4_no_matching_group():
+    estimate = estimate_file_time(codec="h264", duration=600.0, width=1920, height=1080, grouped_percentiles={})
+    assert estimate.confidence == "none"
+    assert estimate.source == "insufficient_data"
+    assert estimate.best_seconds == 0
+
+
+def test_missing_duration_short_circuits():
+    estimate = estimate_file_time(
+        codec="h264", width=1920, height=1080, grouped_percentiles={("h264", "1080p"): STATS_10}
+    )
+    assert estimate.confidence == "none"
+    assert estimate.source == "no_duration"
+
+
+def test_unknown_resolution_skips_tier1():
+    estimate = estimate_file_time(
+        codec="h264", duration=600.0, grouped_percentiles={("h264", "unknown"): STATS_10, ("h264", None): STATS_5}
+    )
+    assert estimate.source == "codec:h264"
+
+
+# ---------------------------------------------------------------------------
+# estimate_current_file_eta
+# ---------------------------------------------------------------------------
+
+
+def test_eta_zero_when_not_running():
+    assert estimate_current_file_eta(False, 100.0, time.time(), 50.0, time.time()) == 0
+
+
+def test_eta_from_stored_ab_av1_value(monkeypatch):
+    monkeypatch.setattr(time, "time", lambda: 1000.0)
+    eta = estimate_current_file_eta(
+        running=True,
+        last_eta_seconds=100.0,
+        last_eta_timestamp=990.0,
+        encoding_progress=50.0,
+        encoding_start_time=900.0,
+    )
+    assert eta == 90.0  # stored ETA minus the 10s elapsed since it was reported
+
+
+def test_eta_from_stored_value_clamps_at_zero(monkeypatch):
+    monkeypatch.setattr(time, "time", lambda: 1000.0)
+    eta = estimate_current_file_eta(
+        running=True,
+        last_eta_seconds=100.0,
+        last_eta_timestamp=850.0,
+        encoding_progress=50.0,
+        encoding_start_time=900.0,
+    )
+    assert eta == 0
+
+
+def test_eta_falls_back_to_progress_extrapolation(monkeypatch):
+    monkeypatch.setattr(time, "time", lambda: 1000.0)
+    eta = estimate_current_file_eta(
+        running=True, last_eta_seconds=None, last_eta_timestamp=None, encoding_progress=50.0, encoding_start_time=900.0
+    )
+    # 100s elapsed at 50% => 200s total => 100s remaining
+    assert eta == 100.0
+
+
+def test_eta_zero_without_progress_or_stored_value():
+    eta = estimate_current_file_eta(
+        running=True, last_eta_seconds=None, last_eta_timestamp=None, encoding_progress=0.0, encoding_start_time=None
+    )
+    assert eta == 0

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,338 @@
+# tests/test_parser.py
+"""Characterization tests for AbAv1Parser.parse_line (src/ab_av1/parser.py).
+
+Lines are modeled on real ab-av1/ffmpeg output as documented in
+docs/AB_AV1_PARSING.md. The stats dict is seeded the same way
+AbAv1Wrapper.auto_encode() seeds it (src/ab_av1/wrapper.py).
+"""
+
+from src.ab_av1.parser import AbAv1Parser
+
+
+class CallbackRecorder:
+    """Stub file_info_callback that records every invocation."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, str, object]] = []
+
+    def __call__(self, filename: str, status: str, info: object) -> None:
+        self.calls.append((filename, status, info))
+
+    @property
+    def events(self) -> list[object]:
+        return [info for _, _, info in self.calls]
+
+
+def make_stats(input_path: str = "/videos/movie.mp4", total_duration_seconds: float | None = 600.0) -> dict:
+    """Seed a stats dict the way AbAv1Wrapper.auto_encode() does."""
+    return {
+        "phase": "crf-search",
+        "progress_quality": 0,
+        "progress_encoding": 0,
+        "vmaf": None,
+        "crf": None,
+        "size_reduction": None,
+        "input_path": input_path,
+        "output_path": "/videos/movie.mkv",
+        "command": "",
+        "vmaf_target_used": 95,
+        "last_ffmpeg_fps": None,
+        "eta_text": None,
+        "total_duration_seconds": total_duration_seconds,
+        "last_reported_encoding_progress": -1.0,
+        "estimated_output_size": None,
+        "estimated_size_reduction": None,
+    }
+
+
+def make_encoding_stats(**kwargs) -> dict:
+    """Stats dict as it looks after the parser's phase transition to encoding."""
+    stats = make_stats(**kwargs)
+    stats.update({"phase": "encoding", "progress_quality": 100.0, "progress_encoding": 0.0, "crf": 30, "vmaf": 95.5})
+    return stats
+
+
+def make_parser() -> tuple[AbAv1Parser, CallbackRecorder]:
+    recorder = CallbackRecorder()
+    return AbAv1Parser(file_info_callback=recorder), recorder
+
+
+# ---------------------------------------------------------------------------
+# CRF search phase
+# ---------------------------------------------------------------------------
+
+
+def test_crf_vmaf_line_updates_stats_and_fires_progress_callback():
+    parser, recorder = make_parser()
+    stats = make_stats()
+
+    parser.parse_line("crf 30 VMAF 96.50 (23%)", stats)
+
+    assert stats["crf"] == 30
+    assert stats["vmaf"] == 96.5
+    assert stats["progress_quality"] == 10.0
+    assert len(recorder.calls) == 1
+    filename, status, event = recorder.calls[0]
+    assert filename == "movie.mp4"  # basename of input_path, not anonymized
+    assert status == "progress"
+    assert event.phase == "crf-search"
+    assert event.progress_quality == 10.0
+    assert event.progress_encoding == 0
+    assert event.message == "Detecting Quality (CRF:30, VMAF:96.5)"
+
+
+def test_repeated_crf_vmaf_lines_cap_quality_progress_at_90():
+    parser, recorder = make_parser()
+    stats = make_stats()
+
+    for i in range(12):
+        parser.parse_line(f"crf {30 + i} VMAF 9{i % 10}.00", stats)
+
+    assert stats["progress_quality"] == 90.0
+    # Callbacks only fire while progress increases: 10 -> 90 in 10% steps.
+    assert len(recorder.calls) == 9
+
+
+def test_best_crf_line_sets_crf_and_95_percent_quality():
+    parser, recorder = make_parser()
+    stats = make_stats()
+
+    parser.parse_line("Best CRF: 31", stats)
+
+    assert stats["crf"] == 31
+    assert stats["progress_quality"] == 95.0
+    assert len(recorder.calls) == 1
+    assert recorder.events[0].crf == 31
+
+
+def test_predicted_size_reduction_line_stores_reduction_without_callback():
+    parser, recorder = make_parser()
+    stats = make_stats()
+
+    parser.parse_line("predicted video stream size 450MB (65%)", stats)
+
+    # Line reports predicted size as 65% of original => 35% reduction.
+    assert stats["size_reduction"] == 35.0
+    # Quality progress did not increase, so no callback fires.
+    assert recorder.calls == []
+
+
+def test_unrelated_line_in_crf_search_changes_nothing():
+    parser, recorder = make_parser()
+    stats = make_stats()
+    before = dict(stats)
+
+    result = parser.parse_line("Svt[info]: SVT [version]: SVT-AV1 Encoder Lib v2.1.0", stats)
+
+    assert result == before
+    assert recorder.calls == []
+
+
+def test_empty_line_returns_stats_unchanged():
+    parser, recorder = make_parser()
+    stats = make_stats()
+    before = dict(stats)
+
+    result = parser.parse_line("   ", stats)
+
+    assert result is stats
+    assert result == before
+    assert recorder.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Phase transition
+# ---------------------------------------------------------------------------
+
+
+def test_encode_log_line_triggers_phase_transition():
+    parser, recorder = make_parser()
+    stats = make_stats()
+    stats.update({"progress_quality": 95.0, "crf": 31, "vmaf": 95.1})
+
+    parser.parse_line("[2024-01-01T00:00:00Z INFO ab_av1::command::encode] encoding video.mkv", stats)
+
+    assert stats["phase"] == "encoding"
+    assert stats["progress_quality"] == 100.0
+    assert stats["progress_encoding"] == 0.0
+    assert len(recorder.calls) == 1
+    event = recorder.events[0]
+    assert event.message == "Encoding started"
+    assert event.phase == "encoding"
+    assert event.progress_quality == 100.0
+    assert event.crf == 31
+
+
+def test_starting_encoding_text_also_triggers_transition():
+    parser, _ = make_parser()
+    stats = make_stats()
+
+    parser.parse_line("Starting encoding", stats)
+
+    assert stats["phase"] == "encoding"
+
+
+def test_encode_log_line_ignored_when_already_encoding():
+    parser, recorder = make_parser()
+    stats = make_encoding_stats()
+
+    parser.parse_line("[2024-01-01T00:00:00Z INFO ab_av1::command::encode] encoding video.mkv", stats)
+
+    assert stats["phase"] == "encoding"
+    assert recorder.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Encoding phase: ab-av1 structured progress
+# ---------------------------------------------------------------------------
+
+
+def test_sample_encode_progress_line():
+    parser, recorder = make_parser()
+    stats = make_encoding_stats()
+
+    parser.parse_line("[2024-01-01T00:00:00Z INFO ab_av1::command::sample_encode] 45.2%, 30 fps, eta 5m 30s", stats)
+
+    assert stats["progress_encoding"] == 45.2
+    assert stats["last_ffmpeg_fps"] == 30
+    assert stats["eta_text"] == "5m 30s"
+    assert len(recorder.calls) == 1
+    event = recorder.events[0]
+    assert event.message == "Encoding: 45.2% (FPS: 30, ETA: 5m 30s)"
+    assert event.progress_encoding == 45.2
+    assert event.eta_text == "5m 30s"
+
+
+def test_main_encode_progress_line():
+    parser, recorder = make_parser()
+    stats = make_encoding_stats()
+
+    parser.parse_line("[2024-01-01T00:00:00Z INFO ab_av1::command::encode] 45%, 30 fps, eta 5m 30s", stats)
+
+    assert stats["progress_encoding"] == 45.0
+    assert stats["last_ffmpeg_fps"] == 30
+    assert stats["eta_text"] == "5m 30s"
+    assert len(recorder.calls) == 1
+    assert recorder.events[0].message == "Encoding: 45.0% (FPS: 30, ETA: 5m 30s)"
+
+
+# ---------------------------------------------------------------------------
+# Encoding phase: raw ffmpeg progress
+# ---------------------------------------------------------------------------
+
+FFMPEG_LINE = "frame= 7500 fps= 25.0 q=30.0 size=   10240kB time=00:05:00.00 bitrate=4500.0kbits/s speed=1.25x"
+
+
+def test_ffmpeg_time_line_computes_progress_from_duration():
+    parser, recorder = make_parser()
+    stats = make_encoding_stats(total_duration_seconds=600.0)
+
+    parser.parse_line(FFMPEG_LINE, stats)
+
+    # 300s of 600s => 50%
+    assert stats["progress_encoding"] == 50.0
+    assert stats["last_ffmpeg_fps"] == 25.0
+    assert len(recorder.calls) == 1
+    event = recorder.events[0]
+    assert event.message == "Encoding: 50.0% (25 fps, 1.25x)"
+    assert event.progress_quality == 100.0
+
+
+def test_ffmpeg_time_line_throttles_repeat_updates():
+    parser, recorder = make_parser()
+    stats = make_encoding_stats(total_duration_seconds=600.0)
+
+    parser.parse_line(FFMPEG_LINE, stats)
+    parser.parse_line(FFMPEG_LINE, stats)  # same timestamp: < 0.1% increase
+
+    assert stats["progress_encoding"] == 50.0
+    assert len(recorder.calls) == 1
+
+
+def test_ffmpeg_time_line_without_duration_is_ignored():
+    parser, recorder = make_parser()
+    stats = make_encoding_stats(total_duration_seconds=None)
+
+    parser.parse_line(FFMPEG_LINE, stats)
+
+    assert stats["progress_encoding"] == 0.0
+    assert recorder.calls == []
+
+
+def test_ffmpeg_progress_never_exceeds_99_9():
+    parser, _ = make_parser()
+    stats = make_encoding_stats(total_duration_seconds=100.0)
+
+    parser.parse_line("frame= 100 fps= 25.0 time=00:02:00.00 speed=1.0x", stats)
+
+    assert stats["progress_encoding"] == 99.9
+
+
+# ---------------------------------------------------------------------------
+# Encoding phase: generic percentage fallback and summary line
+# ---------------------------------------------------------------------------
+
+
+def test_generic_percentage_fallback():
+    parser, recorder = make_parser()
+    stats = make_encoding_stats()
+
+    parser.parse_line("progress: 62%", stats)
+
+    assert stats["progress_encoding"] == 62.0
+    assert len(recorder.calls) == 1
+    assert recorder.events[0].message == "Encoding: 62.0%"
+
+
+def test_generic_percentage_fallback_can_regress_progress():
+    # SUSPECTED BUG: unlike the ffmpeg time= path (which requires a 0.1%
+    # increase), the generic percentage fallback overwrites progress
+    # unconditionally, so a stray low percentage in any output line drags the
+    # progress bar backwards. Pinning current behavior.
+    parser, recorder = make_parser()
+    stats = make_encoding_stats()
+    stats["progress_encoding"] = 80.0
+
+    parser.parse_line("some tool output mentioning 10%", stats)
+
+    assert stats["progress_encoding"] == 10.0
+    assert len(recorder.calls) == 1
+
+
+def test_ab_av1_summary_line_updates_eta_only():
+    parser, recorder = make_parser()
+    stats = make_encoding_stats()
+    stats["progress_encoding"] = 42.0
+
+    parser.parse_line("00:00:37 Encoding -------- (encoding, eta 36m)", stats)
+
+    assert stats["eta_text"] == "36m"
+    assert stats["progress_encoding"] == 42.0  # percentage untouched
+    assert len(recorder.calls) == 1
+    assert recorder.events[0].message == "Encoding: 42.0% (ETA: 36m)"
+
+    # Same ETA again: no duplicate callback (throttled on ETA change).
+    parser.parse_line("00:00:42 Encoding -------- (encoding, eta 36m)", stats)
+    assert len(recorder.calls) == 1
+
+
+def test_unrelated_line_in_encoding_phase_changes_nothing():
+    parser, recorder = make_parser()
+    stats = make_encoding_stats()
+    before = dict(stats)
+
+    parser.parse_line("Svt[info]: Number of logical cores available: 16", stats)
+
+    assert stats == before
+    assert recorder.calls == []
+
+
+def test_parse_line_without_callback_does_not_raise():
+    parser = AbAv1Parser(file_info_callback=None)
+    stats = make_stats()
+
+    parser.parse_line("crf 30 VMAF 96.50", stats)
+    parser.parse_line("Best CRF: 30", stats)
+
+    assert stats["crf"] == 30
+    assert stats["progress_quality"] == 95.0

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -1,0 +1,125 @@
+# tests/test_privacy.py
+"""Characterization tests for the pure anonymization functions in src/privacy.py.
+
+PathPrivacyFilter is intentionally NOT tested here (its behavior is in flux).
+"""
+
+import re
+
+import pytest
+from src.privacy import anonymize_file, anonymize_folder, anonymize_path, set_anonymization_folders
+
+FILE_PATTERN = re.compile(r"^file_[0-9a-f]{12}\.mp4$")
+FOLDER_PATTERN = re.compile(r"^folder_[0-9a-f]{12}$")
+
+
+@pytest.fixture(autouse=True)
+def reset_configured_folders():
+    """Keep the module-level input/output folder config from leaking between tests."""
+    set_anonymization_folders(None, None)
+    yield
+    set_anonymization_folders(None, None)
+
+
+# ---------------------------------------------------------------------------
+# anonymize_file
+# ---------------------------------------------------------------------------
+
+
+def test_anonymize_file_shape_and_extension():
+    result = anonymize_file("movie.mp4")
+    assert FILE_PATTERN.match(result)
+    assert result.endswith(".mp4")
+
+
+def test_anonymize_file_is_deterministic():
+    assert anonymize_file("movie.mp4") == anonymize_file("movie.mp4")
+
+
+def test_anonymize_file_different_names_get_different_hashes():
+    assert anonymize_file("movie.mp4") != anonymize_file("other.mp4")
+
+
+def test_anonymize_file_hash_ignores_extension():
+    # Hash is computed from the stem only; extension is carried over verbatim.
+    mp4 = anonymize_file("movie.mp4")
+    mkv = anonymize_file("movie.mkv")
+    assert mp4.removesuffix(".mp4") == mkv.removesuffix(".mkv")
+
+
+def test_anonymize_file_uses_basename_of_full_path():
+    assert anonymize_file("/some/folder/movie.mp4") == anonymize_file("movie.mp4")
+
+
+def test_anonymize_file_empty_string():
+    assert anonymize_file("") == "file_unknown"
+
+
+# ---------------------------------------------------------------------------
+# anonymize_folder
+# ---------------------------------------------------------------------------
+
+
+def test_anonymize_folder_shape_and_determinism():
+    result = anonymize_folder("/videos/library")
+    assert FOLDER_PATTERN.match(result)
+    assert anonymize_folder("/videos/library") == result
+
+
+def test_anonymize_folder_different_paths_get_different_hashes():
+    assert anonymize_folder("/videos/library") != anonymize_folder("/videos/other")
+
+
+def test_anonymize_folder_normalizes_trailing_slash():
+    assert anonymize_folder("/videos/library/") == anonymize_folder("/videos/library")
+
+
+def test_anonymize_folder_empty_string():
+    assert anonymize_folder("") == "[unknown]"
+
+
+def test_configured_input_and_output_folders_get_labels():
+    set_anonymization_folders("/videos/in", "/videos/out")
+
+    assert anonymize_folder("/videos/in") == "[input_folder]"
+    assert anonymize_folder("/videos/in/") == "[input_folder]"
+    assert anonymize_folder("/videos/out") == "[output_folder]"
+    # Subfolders and unrelated folders still hash.
+    assert FOLDER_PATTERN.match(anonymize_folder("/videos/in/season1"))
+    assert FOLDER_PATTERN.match(anonymize_folder("/videos/elsewhere"))
+
+
+def test_clearing_configured_folders_restores_hashing():
+    set_anonymization_folders("/videos/in", None)
+    assert anonymize_folder("/videos/in") == "[input_folder]"
+
+    set_anonymization_folders(None, None)
+    assert FOLDER_PATTERN.match(anonymize_folder("/videos/in"))
+
+
+# ---------------------------------------------------------------------------
+# anonymize_path
+# ---------------------------------------------------------------------------
+
+
+def test_anonymize_path_combines_folder_and_file():
+    result = anonymize_path("/videos/library/movie.mp4")
+    folder_part, file_part = result.split("/")
+    assert folder_part == anonymize_folder("/videos/library")
+    assert file_part == anonymize_file("movie.mp4")
+
+
+def test_anonymize_path_uses_input_folder_label():
+    set_anonymization_folders("/videos/in", None)
+    result = anonymize_path("/videos/in/movie.mp4")
+    assert result == f"[input_folder]/{anonymize_file('movie.mp4')}"
+
+
+def test_anonymize_path_empty_string():
+    assert anonymize_path("") == "[unknown]/file_unknown"
+
+
+def test_anonymize_path_bare_filename_gets_unknown_folder():
+    # A bare filename has no dirname, which anonymize_folder maps to "[unknown]".
+    result = anonymize_path("movie.mp4")
+    assert result == f"[unknown]/{anonymize_file('movie.mp4')}"

--- a/tests/test_tree_formatters.py
+++ b/tests/test_tree_formatters.py
@@ -1,0 +1,130 @@
+# tests/test_tree_formatters.py
+"""Characterization tests for the pure formatting/parsing functions in
+src/gui/tree_formatters.py (the module has no tkinter dependency; the
+tree-sorting helpers that take a gui object are not covered here)."""
+
+import math
+
+from src.gui.tree_formatters import (
+    format_compact_time,
+    format_efficiency,
+    parse_efficiency_to_value,
+    parse_size_to_bytes,
+    parse_time_to_seconds,
+)
+
+GIB = 1024**3
+
+# ---------------------------------------------------------------------------
+# format_compact_time
+# ---------------------------------------------------------------------------
+
+
+def test_format_compact_time_zero_and_negative_show_dash():
+    assert format_compact_time(0) == "—"
+    assert format_compact_time(-5) == "—"
+
+
+def test_format_compact_time_hours_and_minutes():
+    assert format_compact_time(8100) == "2h 15m"  # default confidence "none": no prefix
+    assert format_compact_time(8100, confidence="high") == "2h 15m"
+    assert format_compact_time(8100, confidence="medium") == "~2h 15m"
+    assert format_compact_time(8100, confidence="low") == "~~2h 15m"
+
+
+def test_format_compact_time_minutes_only():
+    assert format_compact_time(2700) == "45m"
+    assert format_compact_time(2700, confidence="medium") == "~45m"
+
+
+def test_format_compact_time_under_one_minute():
+    assert format_compact_time(30) == "< 1m"
+    assert format_compact_time(30, confidence="medium") == "~< 1m"
+    assert format_compact_time(30, confidence="low") == "~~< 1m"
+
+
+# ---------------------------------------------------------------------------
+# format_efficiency
+# ---------------------------------------------------------------------------
+
+
+def test_format_efficiency_invalid_inputs_show_dash():
+    assert format_efficiency(0, 3600) == "—"
+    assert format_efficiency(-100, 3600) == "—"
+    assert format_efficiency(GIB, 0) == "—"
+
+
+def test_format_efficiency_one_decimal_below_threshold():
+    assert format_efficiency(GIB, 1800) == "2.0 GB/h"
+    assert format_efficiency(int(2.5 * GIB), 3600) == "2.5 GB/h"
+
+
+def test_format_efficiency_no_decimals_at_or_above_10():
+    assert format_efficiency(12 * GIB, 3600) == "12 GB/h"
+    assert format_efficiency(10 * GIB, 3600) == "10 GB/h"
+
+
+# ---------------------------------------------------------------------------
+# parse_size_to_bytes
+# ---------------------------------------------------------------------------
+
+
+def test_parse_size_to_bytes_units():
+    assert parse_size_to_bytes("500 B") == 500
+    assert parse_size_to_bytes("500 KB") == 500 * 1024
+    assert parse_size_to_bytes("500 MB") == 500 * 1024**2
+    assert parse_size_to_bytes("1.2 GB") == 1.2 * GIB
+    assert parse_size_to_bytes("2 TB") == 2 * 1024**4
+
+
+def test_parse_size_to_bytes_strips_estimate_prefix():
+    assert parse_size_to_bytes("~1.2 GB") == parse_size_to_bytes("1.2 GB")
+
+
+def test_parse_size_to_bytes_invalid_values_sort_last():
+    assert parse_size_to_bytes("—") == math.inf
+    assert parse_size_to_bytes("garbage") == math.inf
+    assert parse_size_to_bytes("5 XB") == math.inf
+    assert parse_size_to_bytes("1 2 GB") == math.inf
+
+
+# ---------------------------------------------------------------------------
+# parse_time_to_seconds
+# ---------------------------------------------------------------------------
+
+
+def test_parse_time_to_seconds_roundtrips_formatted_values():
+    assert parse_time_to_seconds("2h 15m") == 8100
+    assert parse_time_to_seconds("~~2h 15m") == 8100
+    assert parse_time_to_seconds("~45m") == 2700
+    assert parse_time_to_seconds("3h") == 10800
+
+
+def test_parse_time_to_seconds_under_one_minute_is_30():
+    assert parse_time_to_seconds("< 1m") == 30
+    assert parse_time_to_seconds("~< 1m") == 30
+    assert parse_time_to_seconds("~~< 1m") == 30
+
+
+def test_parse_time_to_seconds_invalid_values_sort_last():
+    assert parse_time_to_seconds("—") == math.inf
+    assert parse_time_to_seconds("nonsense") == math.inf
+    # Quirk (pinned): a parsed total of exactly zero is treated as unparseable.
+    assert parse_time_to_seconds("0m") == math.inf
+
+
+# ---------------------------------------------------------------------------
+# parse_efficiency_to_value
+# ---------------------------------------------------------------------------
+
+
+def test_parse_efficiency_to_value():
+    assert parse_efficiency_to_value("2.5 GB/h") == 2.5
+    assert parse_efficiency_to_value("12 GB/h") == 12
+
+
+def test_parse_efficiency_to_value_invalid_values_sort_last():
+    assert parse_efficiency_to_value("—") == -math.inf
+    assert parse_efficiency_to_value("5 MB/h") == -math.inf  # only GB/h is recognized
+    assert parse_efficiency_to_value("junk") == -math.inf
+    assert parse_efficiency_to_value("1 2 GB/h") == -math.inf

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,8 @@ source = { editable = "." }
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -17,8 +19,174 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "ruff" },
     { name = "ty" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.15.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/83/6051c2a2feab48ae5bd27c84ef047191d2d4a3172f689e38eaa48ed17db1/coverage-7.15.1.tar.gz", hash = "sha256:165e9949eaf222ef1f018635d0d7f368a23bfe0212af558534c40d8c04686d67", size = 927640, upload-time = "2026-07-12T20:58:19.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/ee/5095e07a0986930174fc153fd0bb115f7f2724f5344cc672e016d4f23a4e/coverage-7.15.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6506330b4a8dcf53b95bd84d8d0e817107cdb3fc1438e835029cdf0bc6612eb0", size = 221320, upload-time = "2026-07-12T20:56:16.036Z" },
+    { url = "https://files.pythonhosted.org/packages/43/7a/7e2598ce98433a214020a61c0755d5961f9f26df0c630dc73e06b86d3416/coverage-7.15.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f8a51a8ec382c39d939cba0ab07ae949077ae4e842343bd4eed22d432358cea9", size = 221823, upload-time = "2026-07-12T20:56:17.54Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/4f/67dac6a69139b490a239d91b6d5ef127982ffb89159769241656ab879ee5/coverage-7.15.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:18ea20e3922d7f8ca9e0ef1084408d08c4ad62d5e531cb9c1f6896a99297ebea", size = 252242, upload-time = "2026-07-12T20:56:18.868Z" },
+    { url = "https://files.pythonhosted.org/packages/05/37/5e439725a96de592309725550c8df639c359c209dcb4b152ed46032d4c0d/coverage-7.15.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:aab9902a64b8390e3b56e539fddae1d79a267807fe5cb0c18d7d2f544ce867e2", size = 254153, upload-time = "2026-07-12T20:56:20.118Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/1c/671ba9e15f9651a99962fb588a1fe4fb267cae4bb85f9bb4ac4413c6f7ef/coverage-7.15.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cc316264317b07a9e90d7f2b4188a15e36e9b54e651081b791b0515fa612a29", size = 256261, upload-time = "2026-07-12T20:56:21.682Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/3c/88305322b4d015b4536b7174b8f9b87f850f01af9d89008cdbf984b65ff2/coverage-7.15.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d4e47e7eea81a8ccf060a07627654151d929da62c7b715738387c200905cec89", size = 258222, upload-time = "2026-07-12T20:56:22.962Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/20/d02e42333a57f266ded61ed4fb3821da1f2dc143734aaa3dcc9c117204c5/coverage-7.15.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c6829d9a3b55ad2b73ef5fda8302e5be03683789e88b1a079dcf4a773229c21d", size = 252368, upload-time = "2026-07-12T20:56:24.475Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d0/94ebc010926a191d83e83b1f1236f8bd0d14d0eb98b5c324aa4be2589a8e/coverage-7.15.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:764e045811f9c8cda436641f3f088283351d331a519b5807f19041cd0a68da1c", size = 253953, upload-time = "2026-07-12T20:56:26.036Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/a6/2c8553191da0c2da2c43ff294fb9bab57a5b0fae03560304a82a8b5addc3/coverage-7.15.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:09b3b088aa24489c4082bcc35fcc8224281ab94a653dfb6d3f0c8165b0d628ab", size = 252016, upload-time = "2026-07-12T20:56:27.374Z" },
+    { url = "https://files.pythonhosted.org/packages/17/99/20f47986d8360fa1a31d9858dd2ba0be009d44ecfa8d02120b1eb93c028b/coverage-7.15.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7911b02f57053adf8164ae63edb1c26574d24dfccabadc5268cf69310a69a358", size = 255783, upload-time = "2026-07-12T20:56:28.921Z" },
+    { url = "https://files.pythonhosted.org/packages/17/36/fb61983b5259f78fa5e62ee74e91fe4de4c556fcbc9a3b9c9021c2f8b57b/coverage-7.15.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:664e279ed40599b8ed16f4db18d92a7e212c73129672bec8f5d96d4da48d2404", size = 251735, upload-time = "2026-07-12T20:56:30.465Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/2e/d109d8d2d6c726ba2e78125297073918a2a91464f0ea777e5398fa3cf75c/coverage-7.15.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:34fe7cf79d5f1f87f2e8ce7dc1c32950841f50e10d0120f263856acfad66de34", size = 252645, upload-time = "2026-07-12T20:56:32.076Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/a0/5b3219cbb46135e14673427f2bf5890c4da4e6f655243692f3448aa3f42c/coverage-7.15.1-cp311-cp311-win32.whl", hash = "sha256:5e2d2536d2f57a354aa382ed303ac0e2e5c9522a508c05b998d26181b94163a7", size = 223414, upload-time = "2026-07-12T20:56:33.432Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/80/24e13ade0b6df8090e2492f9c55044bf1423f7ef28c76fc1af8c827a61cb/coverage-7.15.1-cp311-cp311-win_amd64.whl", hash = "sha256:c337da8fca7ea93ab43f3868cfcde6cf6dad32c3906b273cfbad5d7390bc423b", size = 223888, upload-time = "2026-07-12T20:56:34.784Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/9e/34659930ae380491af48e2f5f5f9a2e99cd9fb7de3d30f27be5ac5425137/coverage-7.15.1-cp311-cp311-win_arm64.whl", hash = "sha256:db3403fdb7a94d5eb73e099befad8104d2a7d110a0f0d99df0de61c5d1fa756c", size = 223435, upload-time = "2026-07-12T20:56:36.302Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/76/32c1826309beaf4604c54accef108fdd611e5e5e93f2f5192f050cd5f6bd/coverage-7.15.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d9476292594309db922cc841dd13b303b3c388f4c25d279884f7e2341c681f80", size = 221497, upload-time = "2026-07-12T20:56:37.628Z" },
+    { url = "https://files.pythonhosted.org/packages/db/5c/b88ce0d68fa550c7f3b58617fbf363bce64df5bf8295a01b627e4696e022/coverage-7.15.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0c579056b0de461b3a62318b63d0b6ce90aed7f8158d3f00da094df82f29d189", size = 221854, upload-time = "2026-07-12T20:56:39.033Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/fe/8509fd2a66fc4e0a829f76a0f0b1dc3cc163368352435b5f243168658077/coverage-7.15.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:23214bdbe226f2b0e9c66a7d6a1d59d4a88045dcf86e702cf0fe0d0935e3d615", size = 253359, upload-time = "2026-07-12T20:56:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/81/c7009ed7ea9765adb2b9d095054d748266fae5f07ac6c5f925f33715fcde/coverage-7.15.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:df164be93b46b4825cc39339440a05edc54c4d1d865ba4a60fd43d151a2a1cd3", size = 256096, upload-time = "2026-07-12T20:56:42.115Z" },
+    { url = "https://files.pythonhosted.org/packages/21/52/dc8ee03968a5ba86e2da5aa48ddc9e3747bd65d63825fdce2d96acb9c5ff/coverage-7.15.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a524fca1a6f08927d9dc2d4c873cfb7bd7202c247f08b14bdc02424071b8b304", size = 257211, upload-time = "2026-07-12T20:56:43.513Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/27/95d7623908da8937deb53d48efcdbf423907a47540e63c62fa21372c652b/coverage-7.15.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d70f3542cd38de85a9e257dcb1ac4c1ab4b6d7d2c2a645809207556628755d1c", size = 259473, upload-time = "2026-07-12T20:56:44.974Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/3b/730d761928de97d585465680b568ae69622fb40716babadeabffe75cb51b/coverage-7.15.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d78aa537237212c4313aabe5e964b66acc86350ed19ebc56a3e202df33b6077b", size = 253759, upload-time = "2026-07-12T20:56:46.615Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fc/6b9277acff1f9484b6c12857af5774689d1a6a95e13265f7405329d2f5da/coverage-7.15.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a318112bb4f79d9d04766196d5a3388caa825908a6a9b052aa87de3d9aea7c61", size = 255131, upload-time = "2026-07-12T20:56:48.073Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/f2/c704f86129594ba34e25a64695d2068c71d51c2b98907184d716c94f4aec/coverage-7.15.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e55d24cada901963eed5bc89fa562aa033f0d84b9d3de4ecf363737c13aed11e", size = 253275, upload-time = "2026-07-12T20:56:49.538Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/29/80fee8af47de4a6dce71ccf2938491f444687a756af258a56d8469b8f1b0/coverage-7.15.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:3c78f0cea7275342cf2adc2ad5fdd0aafa106ad91e66d573568f2fcf62c41df5", size = 257345, upload-time = "2026-07-12T20:56:51.038Z" },
+    { url = "https://files.pythonhosted.org/packages/20/21/a1e7d7ed1b48a8adf8fd5154d9e83fcc5ad8e6ff20ae00e44865057dce8d/coverage-7.15.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:86bd37eabe39977216f630a7fc1b698e7f5e81a191c7186013245c6c3d313f9d", size = 252844, upload-time = "2026-07-12T20:56:52.535Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/8c/a4bc26e6ee207d412f3678f04d74be1550e83140563ca0e4997510579712/coverage-7.15.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c6db15c217693bdc3ca0b84de1ba9afafe1c14c26a8a29d77f4ed0de2b6132e2", size = 254716, upload-time = "2026-07-12T20:56:53.968Z" },
+    { url = "https://files.pythonhosted.org/packages/11/9d/8ad0266ecfada6353cf6627a1a02294cf55a907521b6ee0bd7b770cfd659/coverage-7.15.1-cp312-cp312-win32.whl", hash = "sha256:359f3fbe09a51500c51966596ee4ee4070b356552c70b3b2420eb200d68e0f76", size = 223554, upload-time = "2026-07-12T20:56:55.583Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6d/24224929e06c6e05a93f738bc5f9e8e6ab658f8f1d9b823e7b85430e28b8/coverage-7.15.1-cp312-cp312-win_amd64.whl", hash = "sha256:fa75dc099c126e941a9c0baa8ebd2cbc78bd778687534fe410baf754f6d9e374", size = 224087, upload-time = "2026-07-12T20:56:57.041Z" },
+    { url = "https://files.pythonhosted.org/packages/35/23/f81441dd01de88e53c97842e706907b307d9078918c3f4998b11e9ac7250/coverage-7.15.1-cp312-cp312-win_arm64.whl", hash = "sha256:26f89cf6d0634375f454fa71057945ad18edb0f1607a90fecf22c57dc3dc289a", size = 223472, upload-time = "2026-07-12T20:56:58.594Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/1e/6fa289d7993a2a39f1b283ddb58c4bfec80f7800be654b8ba8a9f6a07c63/coverage-7.15.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:71ac4ca1658ca99160fd58cc6967110e989c34b04627f24ed6ec9f70fb24571a", size = 221519, upload-time = "2026-07-12T20:57:00.081Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/e1/0db4902a0588234a70ab0218073c0b20fbc5c740aa35f91d360160a2ebc9/coverage-7.15.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:26a40cbf2b13bd94af53ee02a424cb3bb96a9edfac0d00834bd068512a62714b", size = 221895, upload-time = "2026-07-12T20:57:01.867Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/cb/3719783865092dac5e08df842730305ee9ab1973ae7ddb6fbdf27d401f30/coverage-7.15.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f4c5a5eff4ad4f9f7088fd3fc7a66d98d06566ee294b3b053309fb0a3b45be1e", size = 252882, upload-time = "2026-07-12T20:57:03.459Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5e/caf3abbdbb22629626160ffc9c017eb995b7cb11c0be46b974834cef1792/coverage-7.15.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:962aa56c1c9b016d681265880eb6acc9966029d2c4c559319cc43a1abbb9b59a", size = 255479, upload-time = "2026-07-12T20:57:04.984Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f1/d60f375bfe095fef944f0f19427aefdbf9bdd5a9571c41a4bf6e2f5fdb81/coverage-7.15.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1678eb2dc57a8ce67601b029582ef6d41e9e6ca22692aaeccd4107e40f27386c", size = 256715, upload-time = "2026-07-12T20:57:06.446Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/17/8b0cbc90d02dc5adad4d9034c1824ec3fa567771b4c39d9c1e3f9b1431b8/coverage-7.15.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1174900a43f6f8c425fee10d7dbddc308adefcdc78aaced32357f5ab750a0e90", size = 258845, upload-time = "2026-07-12T20:57:08.092Z" },
+    { url = "https://files.pythonhosted.org/packages/92/29/c5e69f5fb75c322e9a3e4ef64d02eebfc3d66efceccc8514ff80a3c13a56/coverage-7.15.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:98847557a6859cadf693792ce89f440cb89692993f60dc6d3a7e35f3d340216f", size = 253098, upload-time = "2026-07-12T20:57:09.636Z" },
+    { url = "https://files.pythonhosted.org/packages/64/57/21144252fdd0c01d707d48fbcea13a80b0b7c42ced3f299f885ab8978c3a/coverage-7.15.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8697b2edb57143546a24389efc11e1b000cd5800fc20d84f04edb601e4a7cfb8", size = 254844, upload-time = "2026-07-12T20:57:11.141Z" },
+    { url = "https://files.pythonhosted.org/packages/59/2a/499a28a322b0ce6768328e6c5bb2e2ad00ac068a7c7adb2ecd8533c8c5d9/coverage-7.15.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:6827ac0519be3fe91bf96b4060eb00d1d24f82649b29862cd75a3cfca248b02a", size = 252807, upload-time = "2026-07-12T20:57:12.678Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/928a95da5da8b60f2b00e1482c7787b3316188e6d2d227fb8e124ada43a1/coverage-7.15.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:2de8ecbbc77c7e4d22572779920ed8979c69168675e96be3a548c996568c6c31", size = 256965, upload-time = "2026-07-12T20:57:14.326Z" },
+    { url = "https://files.pythonhosted.org/packages/16/10/889adbc1b8c9f866ed51e18a98bcafc0259fb9d29b81f50a719407c64ea8/coverage-7.15.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2b25f0f0fa5260df9d7bb55d47c8bdc23fa3382c1a18f7c9cae122e6c320b1ad", size = 252628, upload-time = "2026-07-12T20:57:15.892Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/30/a5e1871e5d93416511f8e359d1ccebfe0cbb050a1bbf7dd20228533ec0cf/coverage-7.15.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4a2effcbd93ae340a58db718fe4181d967f84d352c4cefeaab4ff82ce813901a", size = 254399, upload-time = "2026-07-12T20:57:17.703Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/26/c36fbffd549dadbdd1a75827528fb00a4c46aa3187b007b750b1e2cebbf2/coverage-7.15.1-cp313-cp313-win32.whl", hash = "sha256:895e65c96aef0cecea250f6e35e9a32f11375514e1a0cb5210e0fda128c04e8e", size = 223564, upload-time = "2026-07-12T20:57:19.253Z" },
+    { url = "https://files.pythonhosted.org/packages/16/fc/becbb9d2c4206d242b9b1e1e8e24a42f7926c0200dd3c788b9fab4bb96d5/coverage-7.15.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6d0a28b63a0d75f9ed5118105d1154fc3aa40a8605a30d5d87e3d043ad90fe7", size = 224106, upload-time = "2026-07-12T20:57:21.108Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/30/1cfc641461369b6858799fca61c0a8b5edc490c519bf7c636ffa6bbf556f/coverage-7.15.1-cp313-cp313-win_arm64.whl", hash = "sha256:b4ee9818e8bae3544379ad2c09b851c4fb886aaa8860d57a1c1316ddcb16db49", size = 223497, upload-time = "2026-07-12T20:57:22.734Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/46/81961952e7aebfb38ad0ae4264e8954cc607a7af9e7ac111f9fa986595cc/coverage-7.15.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:a886af95f59edf67d5770fd3564d53f4a8af93f25f8c1d60d27e00d7f5674ee8", size = 221560, upload-time = "2026-07-12T20:57:24.282Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d2/ee14d715889f216baf47301d9f469e08fff6995552aaf67e897b282865f6/coverage-7.15.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:985657ebd707941de90d488d1cbb5efac20bdf81f7b91eba771624ccda4d36f4", size = 221894, upload-time = "2026-07-12T20:57:25.87Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/38/f830bc6e6c2c5f23f43847125e6c650d378872f7eeba8d49f1d42193e8a9/coverage-7.15.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5bbe2a06e0a5e1404d9ffbdb49b819bbd6a3bb198ebea4c8dfe7ad9f1e1c2e81", size = 252938, upload-time = "2026-07-12T20:57:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/53/0d3dd963631259d794c898735d5436e68d6a8d40749c419a07ff7c171469/coverage-7.15.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bde0fe24083d0b7b3dbafa7a09f0796410af1afa2523f28f5f208d8340a4aaca", size = 255445, upload-time = "2026-07-12T20:57:29.234Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/fd/aabed228557565c958259251b89bab8c5669b31291fa63b3e2154ebb017a/coverage-7.15.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f89f7453d6d46db14cf233e2cd8edcd78de2b9c49d4f1dc109590b4e5dbfbb74", size = 256790, upload-time = "2026-07-12T20:57:30.826Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/aa/1cc888e5d3623e603c4e5399653cb25728bb2b40d7519188a3e293d24620/coverage-7.15.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc3656c9ecc27b36bd0907455b77f83c0069ca9ad4a66dec892b76c696eb6047", size = 259104, upload-time = "2026-07-12T20:57:32.63Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/61/fc16d5f5e53098dae41efa21e8ccc611a9b4fe922750dd03dc56db552182/coverage-7.15.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:24d8e85a2a45e44883b488c2659f51fa761dad5353fdb319b672a93facbd2ca9", size = 252956, upload-time = "2026-07-12T20:57:34.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/f3/52384668c3de4519ca770bf1975a89e4d6eb5aa2faf0da0577a14008cba4/coverage-7.15.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:68931b5fe746ed4fdaa8892989cab9e6c35781eeb3b0ab2ded893d561e1b3652", size = 254797, upload-time = "2026-07-12T20:57:35.947Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/68/54b807e7c1868178e902fd8360b5d4e559394462f97285c50edf1c4608db/coverage-7.15.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:1ce6947e2a95534ecaa5a15e73c21e550514c980d80eda204d064d789a95f6a4", size = 252762, upload-time = "2026-07-12T20:57:37.856Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/48/dde8adf0338e3ace738757dccf1ce817e5fdcadfae77e1b48a77e5a3b265/coverage-7.15.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:841befdbc89b9c82435fc25b0f4f41858b6238693e45af758bec4cfc1968171c", size = 257037, upload-time = "2026-07-12T20:57:39.488Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f2/179dd88cf60a0aeeee16a970ffe250dccea8b80ed4beab4c5d3f6c41ad4b/coverage-7.15.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5d3de58b837375e7f4c0e1a088ccab5f655efb2fd7427b729df02c862a559633", size = 252577, upload-time = "2026-07-12T20:57:41.363Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/37/8a593d69ab521beb6a105a2017cac4ba94425ee0a8349e29c3c0b522d24f/coverage-7.15.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b1801963f9f44ae0c0f6d737bc7aeb2bbcde7d1fe7e3b43cddc1961af42d3b41", size = 254235, upload-time = "2026-07-12T20:57:43.025Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/34/bc9b3bced66f2cdad4bf5e57ae51c54ea226e8aaaebfc9370a9a11877bf3/coverage-7.15.1-cp314-cp314-win32.whl", hash = "sha256:8c7953c4128ef53b6ffb5f90d87c87d4ce26731df294760bb2314eb0e069e44b", size = 223771, upload-time = "2026-07-12T20:57:44.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f3/4d20337bed61915d14349e62b88d5e4144d5a9872b64adbe90e9906db6db/coverage-7.15.1-cp314-cp314-win_amd64.whl", hash = "sha256:6f0bab60a582d415f0fb535ccff13ba334a47a1538f98913330a525d23bd535a", size = 224257, upload-time = "2026-07-12T20:57:46.412Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/df/bbfeae4948f3ded516f92b32f2d57952427fc5ecfc0924487bb6ee6a5f38/coverage-7.15.1-cp314-cp314-win_arm64.whl", hash = "sha256:0f410ee8f0ac4ec7db71bc0b7632a8b9994e1cad2755bd1566c17e6a162caa74", size = 223683, upload-time = "2026-07-12T20:57:48.106Z" },
+    { url = "https://files.pythonhosted.org/packages/35/65/0b431856064e387d1f5cf474625e4a0465e907024d42f35de6af19ced0be/coverage-7.15.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:fc868bab88e049d41fcd41766810d790a8b960053be2a45e060f5ce0d31d258b", size = 222298, upload-time = "2026-07-12T20:57:49.882Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/96/50eac9bd49df8a3df5f3d38746d1bf332299dffb554486c94ebd55c9dc49/coverage-7.15.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:206d4ec6028f2773b40932d09f074539d6bcdd8f6b318d40cb04bdbd68ed0b49", size = 222561, upload-time = "2026-07-12T20:57:51.688Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/5b/6ba1c4a27e10b8816fd2622b98162c83d3bdf1185097360373611bf96364/coverage-7.15.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:620482ef1c9f4e61f962e159325fe77dea59d16e39d9c9470d069053b244d864", size = 263923, upload-time = "2026-07-12T20:57:53.392Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/59/fe03ade97a3ca2d890e98c572cf48a99fda9adba85757c34b823f41efe1e/coverage-7.15.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d385fc9b054e309ad3cecdc77b586d2af0c98aeec2fdb3773544586f366e817c", size = 266043, upload-time = "2026-07-12T20:57:55.095Z" },
+    { url = "https://files.pythonhosted.org/packages/16/e0/55c4b1217a572a43e13b39e1eb78d0da29fb23679003bd0cdf22c50b1978/coverage-7.15.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1198bca9c0dd7c188aae1f185b0c0b5fc4f0a2b6909000858c29550320bdb07", size = 268465, upload-time = "2026-07-12T20:57:57.017Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e2/ee47944f76afc03909119b036fe9e0da8cbd274a5141287de79791a0fb6d/coverage-7.15.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5d0297e6a070eadb49df7cddd0ab6f420b8b689dd8904c7dd815a323168fa57e", size = 269584, upload-time = "2026-07-12T20:57:58.958Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/8a/6b4d9779c7b2e21c3d12c3425e3261aa7411399319e27aa402dfec4db5d0/coverage-7.15.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:916fcf2214f56960e409561b37fc32a160a42b6e85483d0652d7b70fa55d707e", size = 263019, upload-time = "2026-07-12T20:58:00.979Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/1e/db5c7fa0c8ba5ece390a1e1a3f30db71d440240a80589df28e66a7503c40/coverage-7.15.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f837bae572c7869ffaa502e604c87e182543012831cf87aae4586ad090ac6dcf", size = 265916, upload-time = "2026-07-12T20:58:03.005Z" },
+    { url = "https://files.pythonhosted.org/packages/83/53/fe5176682b00709b13fab36addd26883139d0dea430816fea412e69255e2/coverage-7.15.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3ea65e3ee6c7c32349fd00559927a9e577bdd72386087eeed1c42b62dfce9b82", size = 263520, upload-time = "2026-07-12T20:58:04.994Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/e7/16f15127be93fbc70c667df5ec5dce934fc76c9b0888d84969a5d5341e2c/coverage-7.15.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:345034976f46a1c54bd17f4e43eb30bb92cb7082fcddff03250cff136cc4eb82", size = 267254, upload-time = "2026-07-12T20:58:06.824Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/73/e5119111f6f065376395a525f7ce6e9174d83f3db6d217ea0211a61cca4d/coverage-7.15.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:4f051a64eb8f8addb4661c2b41d6eea5b7ebc68ad4b2baea8d9bc54e1956e5f7", size = 262366, upload-time = "2026-07-12T20:58:08.555Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/9c/6d0a81182df18a73b081e7a8630f0e2a52b12dfd7898c6ab839551a454d2/coverage-7.15.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a7625770f7720b49bb30d194ad2f8d50fab3c5177874af3d2399676f95f9c594", size = 264680, upload-time = "2026-07-12T20:58:10.359Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a2/bac0cbd4450638f1be2041a464b1766c8cc94abf705a2df6f1c8d4be870d/coverage-7.15.1-cp314-cp314t-win32.whl", hash = "sha256:81e503d130a472ad1bd38199ecd35116b40d92bcd31e27a2cacde035381f2070", size = 224077, upload-time = "2026-07-12T20:58:12.065Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b2/d83c5403155172a43ba47c08641bad3f89822d8405102423a41339d2c857/coverage-7.15.1-cp314-cp314t-win_amd64.whl", hash = "sha256:724e878b213b302ad46e9f2fc872d386613f20ebfc492a211482d917ea76c14f", size = 224908, upload-time = "2026-07-12T20:58:13.956Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/41/442b74cad832cc77712080585455482e7cc4f4a9a13192f65731dcd18231/coverage-7.15.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ce2f05c14d077f406fefc4fa5e4f093ad0e0787549f6582535d6e28766f0361b", size = 224219, upload-time = "2026-07-12T20:58:16.315Z" },
+    { url = "https://files.pythonhosted.org/packages/34/98/07a67cf1a26e795d617ed5c540c042b0ac87b72f810c30c07f076cf334f3/coverage-7.15.1-py3-none-any.whl", hash = "sha256:717d01e6e00bed56ad13306f19e0dd2f4f645ee8159d2c72c72301d6cfc7090c", size = 213284, upload-time = "2026-07-12T20:58:18.079Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]
@@ -45,6 +213,60 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/0d/15cc82da5d83f27a3c6b04f3a232d61bc8c50d38a6cd8da79228e5f8b8d6/ruff-0.14.9-py3-none-win32.whl", hash = "sha256:df0937f30aaabe83da172adaf8937003ff28172f59ca9f17883b4213783df197", size = 13202651, upload-time = "2025-12-11T21:39:26.628Z" },
     { url = "https://files.pythonhosted.org/packages/32/f7/c78b060388eefe0304d9d42e68fab8cffd049128ec466456cef9b8d4f06f/ruff-0.14.9-py3-none-win_amd64.whl", hash = "sha256:c0b53a10e61df15a42ed711ec0bda0c582039cf6c754c49c020084c55b5b0bc2", size = 14702079, upload-time = "2025-12-11T21:39:11.954Z" },
     { url = "https://files.pythonhosted.org/packages/26/09/7a9520315decd2334afa65ed258fed438f070e31f05a2e43dd480a5e5911/ruff-0.14.9-py3-none-win_arm64.whl", hash = "sha256:8e821c366517a074046d92f0e9213ed1c13dbc5b37a7fc20b07f79b64d62cc84", size = 13744730, upload-time = "2025-12-11T21:39:29.659Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
First wave of fixes from an architectural review of the whole app: it introduces the project's test suite, closes a privacy leak in log scrubbing, and clears out small config/state/doc debt. All changes are independent of each other; none change conversion behavior.

**Testing policy change**: `AGENTS.md` drops the "No tests" rule. The repo now has pytest with 81 unit tests over the pure modules (`ab_av1/parser`, `estimation`, `privacy`, `cache_helpers`, `gui/tree_formatters`), run via `uv run pytest`. Tests pin current behavior as a safety net for upcoming refactors; GUI and worker code stay exempt until the engine/GUI boundary refactor lands.

**Privacy fix**: `PathPrivacyFilter` only scrubbed `record.msg`, so paths passed as `%`-style logging args (for example `logger.info("re-deriving record: %s", filename)`) reached log files raw. The filter now collapses the record to its formatted message before scrubbing when args are present.

**Config/state hygiene**:
- `MTIME_TOLERANCE` moved to `config.py` beside `DURATION_TOLERANCE_SEC`; tree heading maps moved from `config.py` to `gui/constants.py`
- Import-time `APP_VERSION` (a tomllib read in a bare `except` silently degrading to "dev") replaced by a cached `get_app_version()` that logs a warning on failure
- `folder_aggregates` is now initialized with the other analysis-state maps, removing the `hasattr`/`getattr` guards around a lazily-conjured attribute
- Removed the duplicate `WM_DELETE_WINDOW` binding in `main.py` (kept the one in `main_window.py` where the handler lives)

**Doc drift**: `AGENTS.md` project tree now matches disk (`history_tab.py` was missing, tab descriptions corrected), and `ARCHITECTURE.md` gains a section on the History, Statistics, and Settings tabs.

Characterization tests surfaced three latent bugs, pinned as current behavior with comments rather than fixed here: the parser's generic percentage fallback can move the progress bar backwards, `parser.py`'s `anonymized_input_basename` is not actually anonymized, and `parse_time_to_seconds("0m")` returns `inf`.

Review order: `src/privacy.py` and `src/config.py` carry the behavior changes; `tests/` is new code; commit `ed76ee8` is formatter-only churn on touched files.
