### PR TITLE
fix(parser): Guard progress against regression; rename raw basename; parse zero times

### DIFF
--- a/src/ab_av1/parser.py
+++ b/src/ab_av1/parser.py
@@ -330,18 +330,24 @@ class AbAv1Parser:
                 percentage_match = self._re_percentage.search(line)
                 if percentage_match:
                     progress_pct = float(percentage_match.group(1))
-                    logger.info(f"Percentage detected in line: {progress_pct}% in '{line}'")
 
-                    # Basic progress update (no FPS or ETA)
-                    stats["progress_encoding"] = progress_pct
+                    # Only update if progress increased by at least 0.1% (same guard as the
+                    # ffmpeg time= path): a stray low percentage in unrelated output must
+                    # never drag the progress bar backwards
+                    last_progress = stats.get("progress_encoding", 0.0)
+                    if progress_pct >= last_progress + 0.1:
+                        logger.info(f"Percentage detected in line: {progress_pct}% in '{line}'")
 
-                    # Send progress update
-                    if self.file_info_callback:
-                        message = f"Encoding: {progress_pct:.1f}%"
-                        callback_data = self._build_encoding_callback_data(stats, progress_pct, message)
-                        self.file_info_callback(anonymized_input_basename, "progress", callback_data)
+                        # Basic progress update (no FPS or ETA)
+                        stats["progress_encoding"] = progress_pct
 
-                    processed_line = True
+                        # Send progress update
+                        if self.file_info_callback:
+                            message = f"Encoding: {progress_pct:.1f}%"
+                            callback_data = self._build_encoding_callback_data(stats, progress_pct, message)
+                            self.file_info_callback(anonymized_input_basename, "progress", callback_data)
+
+                        processed_line = True
 
                 # Fall back to ab-av1 summary line if no ffmpeg progress
                 summary_match = self._re_ab_av1_encoding_summary.search(line)

--- a/src/ab_av1/parser.py
+++ b/src/ab_av1/parser.py
@@ -117,7 +117,7 @@ class AbAv1Parser:
             return stats  # Skip empty lines
 
         try:
-            anonymized_input_basename = os.path.basename(stats.get("input_path", "unknown_file"))
+            input_basename = os.path.basename(stats.get("input_path", "unknown_file"))
             current_phase = stats.get("phase", "crf-search")
             processed_line = False  # Flag if line yielded useful info
 
@@ -152,7 +152,7 @@ class AbAv1Parser:
                         original_size=stats.get("original_size"),
                         vmaf_target_used=stats.get("vmaf_target_used"),
                     )
-                    self.file_info_callback(anonymized_input_basename, "progress", callback_info)
+                    self.file_info_callback(input_basename, "progress", callback_info)
                 return stats  # Return early
 
             # --- CRF Search Phase Parsing ---
@@ -227,7 +227,7 @@ class AbAv1Parser:
                             original_size=stats.get("original_size"),
                             vmaf_target_used=stats.get("vmaf_target_used"),
                         )
-                        self.file_info_callback(anonymized_input_basename, "progress", callback_info)
+                        self.file_info_callback(input_basename, "progress", callback_info)
 
             # --- Encoding Phase Parsing (ab-av1 Summary Line) ---
             elif current_phase == "encoding":
@@ -249,7 +249,7 @@ class AbAv1Parser:
                     if self.file_info_callback:
                         message = f"Encoding: {progress_pct:.1f}% (FPS: {fps}, ETA: {eta_text})"
                         callback_data = self._build_encoding_callback_data(stats, progress_pct, message, eta_text)
-                        self.file_info_callback(anonymized_input_basename, "progress", callback_data)
+                        self.file_info_callback(input_basename, "progress", callback_data)
 
                     processed_line = True
                     return stats
@@ -274,7 +274,7 @@ class AbAv1Parser:
                     if self.file_info_callback:
                         message = f"Encoding: {progress_pct:.1f}% (FPS: {fps}, ETA: {eta_text})"
                         callback_data = self._build_encoding_callback_data(stats, progress_pct, message, eta_text)
-                        self.file_info_callback(anonymized_input_basename, "progress", callback_data)
+                        self.file_info_callback(input_basename, "progress", callback_data)
 
                     processed_line = True
                     return stats
@@ -319,7 +319,7 @@ class AbAv1Parser:
 
                                 if self.file_info_callback:
                                     callback_data = self._build_encoding_callback_data(stats, progress_pct, message)
-                                    self.file_info_callback(anonymized_input_basename, "progress", callback_data)
+                                    self.file_info_callback(input_basename, "progress", callback_data)
 
                                 processed_line = True
                                 return stats
@@ -345,7 +345,7 @@ class AbAv1Parser:
                         if self.file_info_callback:
                             message = f"Encoding: {progress_pct:.1f}%"
                             callback_data = self._build_encoding_callback_data(stats, progress_pct, message)
-                            self.file_info_callback(anonymized_input_basename, "progress", callback_data)
+                            self.file_info_callback(input_basename, "progress", callback_data)
 
                         processed_line = True
 
@@ -369,7 +369,7 @@ class AbAv1Parser:
                                     stats, current_progress, message, eta_text
                                 )
                                 logger.debug(f"Sending progress callback (summary): {current_progress:.1f}%")
-                                self.file_info_callback(anonymized_input_basename, "progress", callback_data)
+                                self.file_info_callback(input_basename, "progress", callback_data)
 
                     except IndexError:
                         logger.warning(f"Error parsing groups from ab-av1 summary line: '{line}'")

--- a/src/gui/tree_formatters.py
+++ b/src/gui/tree_formatters.py
@@ -125,18 +125,21 @@ def parse_time_to_seconds(time_str: str) -> float:
     time_str = time_str.lstrip("~")
 
     total_seconds = 0.0
+    parsed_any = False
     # Parse patterns like "2h 15m" or "45m"
     parts = time_str.split()
     for part in parts:
         try:
             if part.endswith("h"):
                 total_seconds += float(part[:-1]) * 3600
+                parsed_any = True
             elif part.endswith("m"):
                 total_seconds += float(part[:-1]) * 60
+                parsed_any = True
         except ValueError:
             continue
 
-    return total_seconds if total_seconds > 0 else float("inf")
+    return total_seconds if parsed_any else float("inf")
 
 
 def parse_efficiency_to_value(eff_str: str) -> float:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -73,7 +73,7 @@ def test_crf_vmaf_line_updates_stats_and_fires_progress_callback():
     assert stats["progress_quality"] == 10.0
     assert len(recorder.calls) == 1
     filename, status, event = recorder.calls[0]
-    assert filename == "movie.mp4"  # basename of input_path, not anonymized
+    assert filename == "movie.mp4"  # raw basename of input_path, kept raw for GUI display
     assert status == "progress"
     assert event.phase == "crf-search"
     assert event.progress_quality == 10.0

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -284,19 +284,18 @@ def test_generic_percentage_fallback():
     assert recorder.events[0].message == "Encoding: 62.0%"
 
 
-def test_generic_percentage_fallback_can_regress_progress():
-    # SUSPECTED BUG: unlike the ffmpeg time= path (which requires a 0.1%
-    # increase), the generic percentage fallback overwrites progress
-    # unconditionally, so a stray low percentage in any output line drags the
-    # progress bar backwards. Pinning current behavior.
+def test_generic_percentage_fallback_never_regresses_progress():
+    # Like the ffmpeg time= path, the generic percentage fallback requires a
+    # 0.1% increase, so a stray low percentage in unrelated output cannot drag
+    # the progress bar backwards.
     parser, recorder = make_parser()
     stats = make_encoding_stats()
     stats["progress_encoding"] = 80.0
 
     parser.parse_line("some tool output mentioning 10%", stats)
 
-    assert stats["progress_encoding"] == 10.0
-    assert len(recorder.calls) == 1
+    assert stats["progress_encoding"] == 80.0
+    assert recorder.calls == []
 
 
 def test_ab_av1_summary_line_updates_eta_only():

--- a/tests/test_tree_formatters.py
+++ b/tests/test_tree_formatters.py
@@ -109,8 +109,12 @@ def test_parse_time_to_seconds_under_one_minute_is_30():
 def test_parse_time_to_seconds_invalid_values_sort_last():
     assert parse_time_to_seconds("—") == math.inf
     assert parse_time_to_seconds("nonsense") == math.inf
-    # Quirk (pinned): a parsed total of exactly zero is treated as unparseable.
-    assert parse_time_to_seconds("0m") == math.inf
+
+
+def test_parse_time_to_seconds_parsed_zero_is_zero():
+    # A successfully parsed zero is a real value (sorts first), not unparseable.
+    assert parse_time_to_seconds("0m") == 0.0
+    assert parse_time_to_seconds("0h 0m") == 0.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Three small defects surfaced by the characterization suite, each with its pinned test flipped to assert the corrected behavior. Refs #23.

The encoding progress bar could move backwards: the parser's generic percentage fallback overwrote `progress_encoding` unconditionally, so a stray "10%" in any output line dragged an 80% bar down to 10. It now requires an increase of at least 0.1%, the same guard the ffmpeg `time=` path already used.

`anonymized_input_basename` in the parser was the raw basename, not anonymized. It must stay raw (the GUI displays it in the current-file label; log lines are scrubbed separately by `PathPrivacyFilter`), so the fix is the honest name `input_basename` at all 8 occurrences.

`parse_time_to_seconds("0m")` returned `inf` because a parsed total of zero was treated as unparseable, making zero-time rows sort as invalid. A successful parse of zero now returns 0.0; genuinely unparseable strings still return `inf`. The only caller is a sort key with no branch on `inf`, so nothing else shifts.
