### PR TITLE
fix(history): Serialize duplicate resolution and debounce saves

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -65,6 +65,9 @@ MAX_VMAF_VALUE = 100  # Maximum valid VMAF score
 
 # --- History File ---
 HISTORY_FILE = "conversion_history.json"
+# Debounce for per-file history saves in the conversion worker: save() rewrites the whole
+# multi-MB JSON, so at most one save per interval; hard checkpoints still flush unconditionally.
+HISTORY_SAVE_INTERVAL_SEC = 30
 
 # --- Settings File ---
 CONFIG_FILE = "ab_av1_gui_config.json"

--- a/src/conversion_engine/worker.py
+++ b/src/conversion_engine/worker.py
@@ -17,7 +17,7 @@ from collections.abc import Callable  # Import Callable
 from src.ab_av1.exceptions import ConversionNotWorthwhileError
 from src.ab_av1.wrapper import AbAv1Wrapper
 from src.cache_helpers import converted_verdict_applies, is_file_unchanged
-from src.config import DEFAULT_ENCODING_PRESET, DEFAULT_VMAF_TARGET, MIN_VMAF_FALLBACK_TARGET
+from src.config import DEFAULT_ENCODING_PRESET, DEFAULT_VMAF_TARGET, HISTORY_SAVE_INTERVAL_SEC, MIN_VMAF_FALLBACK_TARGET
 from src.hardware_accel import get_hw_decoder_for_codec, get_video_codec_from_info
 from src.history_index import (
     HistoryIndex,
@@ -166,10 +166,16 @@ def _create_file_record(
 
 
 def _save_file_record(record: FileRecord) -> None:
-    """Save a FileRecord to the history index."""
+    """Record a FileRecord in the history index; disk writes are debounced.
+
+    save_if_stale keeps per-file processing from rewriting the whole multi-MB
+    history JSON every time. The worker flushes unconditionally at queue-item
+    completion and on exit, so at most HISTORY_SAVE_INTERVAL_SEC of records is
+    ever at risk from a crash.
+    """
     index = get_history_index()
     index.upsert(record)
-    index.save()
+    index.save_if_stale(HISTORY_SAVE_INTERVAL_SEC)
 
 
 def _find_duplicate_verdict(
@@ -239,7 +245,7 @@ def _persist_duplicate_alias(
             anonymize,
         )
         index.upsert(alias)
-        index.save()
+        index.save_if_stale(HISTORY_SAVE_INTERVAL_SEC)
         logger.debug(
             "Aliased %s record to queued path %s (duplicate detection)", source.status, anonymize_filename(file_path)
         )
@@ -350,439 +356,642 @@ def sequential_conversion_worker(
     retry_count = 0
     max_retries = 10
 
-    while not stop_event.is_set():
-        # Fetch next pending item dynamically
-        queue_item, remaining_pending, timed_out = get_next_item_callback()
+    try:
+        while not stop_event.is_set():
+            # Fetch next pending item dynamically
+            queue_item, remaining_pending, timed_out = get_next_item_callback()
 
-        if timed_out:
-            retry_count += 1
-            if retry_count > max_retries:
-                logger.error(f"Failed to fetch queue item after {max_retries} retries")
-                break
-            logger.warning(f"Retry {retry_count}/{max_retries} fetching queue item...")
-            time.sleep(0.5 * retry_count)  # Exponential backoff
-            continue
+            if timed_out:
+                retry_count += 1
+                if retry_count > max_retries:
+                    logger.error(f"Failed to fetch queue item after {max_retries} retries")
+                    break
+                logger.warning(f"Retry {retry_count}/{max_retries} fetching queue item...")
+                time.sleep(0.5 * retry_count)  # Exponential backoff
+                continue
 
-        retry_count = 0  # Reset on success
+            retry_count = 0  # Reset on success
 
-        if queue_item is None:
-            # No more pending items
-            logger.info("No more pending queue items")
-            break
-
-        # Update items_total dynamically (remaining + 1 for current + completed)
-        items_total = remaining_pending + 1 + items_completed
-
-        logger.info(f"Processing queue item {items_completed + 1}/{items_total}: {queue_item.source_path}")
-        queue_item.processed_files = 0
-        # Reset outcome counters for fresh processing
-        queue_item.files_succeeded = 0
-        queue_item.files_skipped = 0
-        queue_item.files_failed = 0
-
-        # Get files for this item
-        # For folders, use the pre-filtered files list from queue_item.files
-        # (populated by create_queue_item with filter_file_for_queue applied)
-        try:
-            files = [f.path for f in queue_item.files] if queue_item.is_folder else [queue_item.source_path]
-            queue_item.total_files = len(files)
-            logger.info(f"Queue item has {len(files)} file(s) to process")
-        except Exception as e:
-            logger.exception(f"Error getting files for queue item {queue_item.id}")
-            queue_item.status = QueueItemStatus.ERROR
-            queue_item.total_files = 0
-            queue_item.last_error = f"Error getting files: {e!s}"
-            queue_status_callback(
-                queue_item.id, QueueItemStatus.ERROR, queue_item.processed_files, queue_item.total_files
-            )
-            continue
-
-        # Handle empty folders
-        if queue_item.total_files == 0:
-            logger.info(f"Queue item {queue_item.source_path} has no eligible video files")
-            queue_item.status = QueueItemStatus.COMPLETED
-            queue_status_callback(queue_item.id, QueueItemStatus.COMPLETED, 0, 0)
-            items_completed += 1
-            continue
-
-        # Update queue status to converting with file count
-        queue_status_callback(queue_item.id, QueueItemStatus.CONVERTING, 0, queue_item.total_files)
-
-        # Process each file in this queue item
-        for file_index, file_path in enumerate(files):
-            if stop_event.is_set():
-                logger.info("Conversion interrupted by user stop request.")
-                # Mark remaining files as stopped and track count
-                remaining_files = queue_item.files[file_index:]
-                stopped_file_count = len(remaining_files)
-                for remaining_file in remaining_files:
-                    remaining_file.status = QueueItemStatus.STOPPED
-                def increment_stopped_count(n=stopped_file_count):
-                    gui.session.stopped_count += n
-
-                update_ui_safely(gui.root, increment_stopped_count)
+            if queue_item is None:
+                # No more pending items
+                logger.info("No more pending queue items")
                 break
 
-            global_file_index += 1
+            # Update items_total dynamically (remaining + 1 for current + completed)
+            items_total = remaining_pending + 1 + items_completed
 
-            # Update current file index and file status
-            queue_item.current_file_index = file_index
-            _update_file_status(queue_item, file_index, QueueItemStatus.CONVERTING)
+            logger.info(f"Processing queue item {items_completed + 1}/{items_total}: {queue_item.source_path}")
+            queue_item.processed_files = 0
+            # Reset outcome counters for fresh processing
+            queue_item.files_succeeded = 0
+            queue_item.files_skipped = 0
+            queue_item.files_failed = 0
 
-            # Store current file path for estimation and callback handlers
-            # Set synchronously - thread-safe per single-writer model (see worker.py:34-44)
-            gui.session.current_file_path = file_path
-            logger.debug(f"Current file path set to: {file_path}")
-
-            filename = os.path.basename(file_path)
-            anonymized_name = anonymize_filename(file_path)
-            # Show overall file progress (filename shown separately in current_file_label)
-            update_ui_safely(
-                gui.root,
-                lambda idx=global_file_index, total=total_files_in_queue: (
-                    gui.status_label.config(text=f"File {idx}/{total}")
-                ),
-            )
-            update_ui_safely(gui.root, reset_ui_callback)  # Reset UI elements for the new file
-
-            # Calculate output path using the new helper (skip for ANALYZE operations)
-            output_path = None
-            overwrite = False
-            delete_original = False
-            if queue_item.operation_type == OperationType.CONVERT:
-                try:
-                    output_path_obj, overwrite, delete_original = calculate_output_path(
-                        input_path=file_path,
-                        output_mode=queue_item.output_mode,
-                        suffix=queue_item.output_suffix or config.default_suffix,
-                        output_folder=queue_item.output_folder,
-                        source_folder=queue_item.source_path if queue_item.is_folder else None,
-                    )
-                    output_path = str(output_path_obj)
-                except Exception as e:
-                    logger.exception(f"Error calculating output path for {anonymized_name}")
-                    error_msg = f"Failed to calculate output path: {e!s}"
-                    file_event_callback(filename, "failed", {"message": error_msg, "type": "path_error"})
-                    queue_item.processed_files += 1
-                    queue_item.files_failed += 1
-                    queue_item.last_error = error_msg
-                    _update_file_status(queue_item, file_index, QueueItemStatus.ERROR, error_msg)
-                    queue_status_callback(
-                        queue_item.id, QueueItemStatus.CONVERTING, queue_item.processed_files, queue_item.total_files
-                    )
-                    continue
-
-            # Check eligibility with new scanner signature (skip for ANALYZE operations)
-            if queue_item.operation_type == OperationType.CONVERT and output_path is not None:
-                try:
-                    needs_conversion, reason, video_info = scan_video_needs_conversion(
-                        input_video_path=file_path,
-                        output_path=output_path,
-                        overwrite=overwrite,
-                        video_info_cache=video_info_cache,
-                    )
-                except Exception as e:
-                    logger.exception(f"Error during eligibility scan for {anonymized_name}")
-                    error_msg = f"Scan error: {e!s}"
-                    file_event_callback(filename, "failed", {"message": error_msg, "type": "scan_error"})
-                    queue_item.processed_files += 1
-                    queue_item.files_failed += 1
-                    queue_item.last_error = error_msg
-                    _update_file_status(queue_item, file_index, QueueItemStatus.ERROR, error_msg)
-                    queue_status_callback(
-                        queue_item.id, QueueItemStatus.CONVERTING, queue_item.processed_files, queue_item.total_files
-                    )
-                    continue
-            else:
-                # ANALYZE operation - always "needs conversion" (really means "needs analysis")
-                needs_conversion = True
-                reason = ""
-
-                try:
-                    video_info = video_info_cache.get(file_path) or get_video_info(file_path)
-                    if video_info and file_path not in video_info_cache:
-                        video_info_cache[file_path] = video_info
-                except Exception as e:
-                    logger.exception(f"Error getting video info for ANALYZE operation: {anonymized_name}")
-                    error_msg = f"Video info error: {e!s}"
-                    file_event_callback(filename, "failed", {"message": error_msg, "type": "video_info_error"})
-                    queue_item.processed_files += 1
-                    queue_item.files_failed += 1
-                    queue_item.last_error = error_msg
-                    _update_file_status(queue_item, file_index, QueueItemStatus.ERROR, error_msg)
-                    queue_status_callback(
-                        queue_item.id, QueueItemStatus.CONVERTING, queue_item.processed_files, queue_item.total_files
-                    )
-                    continue
-
-            if queue_item.operation_type == OperationType.CONVERT and not needs_conversion:
-                # File doesn't need conversion, skip it
-                filename_skip = os.path.basename(file_path)
-                file_event_callback(filename_skip, "skipped", reason)
-
-                # Check if skipped due to resolution (thread-safe)
-                if "Below minimum resolution" in reason:
-
-                    def update_low_res_skip(fn=filename_skip):
-                        gui.session.skipped_low_resolution_count += 1
-                        gui.session.skipped_low_resolution_files.append(fn)
-
-                    update_ui_safely(gui.root, update_low_res_skip)
-
-                queue_item.processed_files += 1
-                queue_item.files_skipped += 1
-                _update_file_status(queue_item, file_index, QueueItemStatus.COMPLETED)
+            # Get files for this item
+            # For folders, use the pre-filtered files list from queue_item.files
+            # (populated by create_queue_item with filter_file_for_queue applied)
+            try:
+                files = [f.path for f in queue_item.files] if queue_item.is_folder else [queue_item.source_path]
+                queue_item.total_files = len(files)
+                logger.info(f"Queue item has {len(files)} file(s) to process")
+            except Exception as e:
+                logger.exception(f"Error getting files for queue item {queue_item.id}")
+                queue_item.status = QueueItemStatus.ERROR
+                queue_item.total_files = 0
+                queue_item.last_error = f"Error getting files: {e!s}"
                 queue_status_callback(
-                    queue_item.id, QueueItemStatus.CONVERTING, queue_item.processed_files, queue_item.total_files
-                )
-                # Update analysis tree - "done" for already-converted, "skip" for others
-                reason_lower = reason.lower() if reason else ""
-                tree_status = "done" if "already converted" in reason_lower else "skip"
-                update_ui_safely(
-                    gui.root,
-                    lambda fp=file_path, s=tree_status: gui.update_analysis_tree_for_completed_file(fp, s)
+                    queue_item.id, QueueItemStatus.ERROR, queue_item.processed_files, queue_item.total_files
                 )
                 continue
 
-            # File needs conversion - proceed with processing
-            original_size = 0
-            input_vcodec = "?"
-            input_acodec = "?"
-            input_duration = 0.0
-            input_width = None
-            input_height = None
-            input_bitrate_kbps = None
-            input_audio_streams = []
-            output_acodec = "?"  # Initialize output audio codec
+            # Handle empty folders
+            if queue_item.total_files == 0:
+                logger.info(f"Queue item {queue_item.source_path} has no eligible video files")
+                queue_item.status = QueueItemStatus.COMPLETED
+                queue_status_callback(queue_item.id, QueueItemStatus.COMPLETED, 0, 0)
+                items_completed += 1
+                continue
 
-            # --- Extract Info & Update UI ---
-            if video_info:
-                try:
-                    meta = extract_video_metadata(video_info)
-                    input_vcodec = (meta.video_codec or "?").upper()
-                    # Get audio codec from first stream (for display purposes)
-                    input_acodec = (meta.audio_streams[0].codec if meta.audio_streams else "?").upper()
-                    input_width = meta.width
-                    input_height = meta.height
-                    input_duration = meta.duration_sec or 0.0
-                    original_size = meta.file_size_bytes or 0
-                    input_bitrate_kbps = meta.bitrate_kbps
-                    input_audio_streams = meta.audio_streams
+            # Update queue status to converting with file count
+            queue_status_callback(queue_item.id, QueueItemStatus.CONVERTING, 0, queue_item.total_files)
 
-                    update_ui_safely(gui.root, lambda os=original_size: setattr(gui.session, "last_input_size", os))
-                    output_acodec = input_acodec  # Default output codec
-                except Exception:
-                    logger.exception(f"Error extracting details from video_info for {anonymized_name}")
-                    update_ui_safely(gui.root, lambda: setattr(gui.session, "last_input_size", None))
-                    input_duration = 0.0
-            else:
-                logger.warning(f"Cannot get pre-conversion info for {anonymized_name}.")
-                update_ui_safely(gui.root, lambda: setattr(gui.session, "last_input_size", None))
-                input_duration = 0.0
+            # Process each file in this queue item
+            for file_index, file_path in enumerate(files):
+                if stop_event.is_set():
+                    logger.info("Conversion interrupted by user stop request.")
+                    # Mark remaining files as stopped and track count
+                    remaining_files = queue_item.files[file_index:]
+                    stopped_file_count = len(remaining_files)
+                    for remaining_file in remaining_files:
+                        remaining_file.status = QueueItemStatus.STOPPED
+                    def increment_stopped_count(n=stopped_file_count):
+                        gui.session.stopped_count += n
 
-            # --- Duplicate Short-Circuit (ADR-001) ---
-            # A physical file already decided under another path must not be re-processed:
-            # skip on CONVERTED / NOT_WORTHWHILE (and on ANALYZED for ANALYZE operations).
-            # An ANALYZED verdict on a CONVERT operation falls through instead - the alias
-            # written here carries the Layer-2 data, so process_video reuses the cached CRF.
-            index = get_history_index()
-            verdict = _find_duplicate_verdict(index, file_path, original_size, input_duration)
-            if verdict is not None:
-                if verdict.duplicate_of is None:
-                    _persist_duplicate_alias(index, verdict, file_path, video_info, anonymize_history_value[0] or False)
-                if verdict.status in (FileStatus.CONVERTED, FileStatus.NOT_WORTHWHILE) or (
-                    verdict.status == FileStatus.ANALYZED and queue_item.operation_type == OperationType.ANALYZE
-                ):
-                    if verdict.status == FileStatus.CONVERTED:
-                        reason, tree_status = "Already converted (duplicate of another path)", "done"
-                    elif verdict.status == FileStatus.NOT_WORTHWHILE:
-                        reason, tree_status = "Not worth converting (duplicate of another path)", "skip"
-                    else:
-                        reason, tree_status = "Already analyzed (duplicate of another path)", "done"
-                    logger.info(f"Skipping {anonymized_name} - {reason}")
-                    file_event_callback(filename, "skipped", reason)
+                    update_ui_safely(gui.root, increment_stopped_count)
+                    break
+
+                global_file_index += 1
+
+                # Update current file index and file status
+                queue_item.current_file_index = file_index
+                _update_file_status(queue_item, file_index, QueueItemStatus.CONVERTING)
+
+                # Store current file path for estimation and callback handlers
+                # Set synchronously - thread-safe per single-writer model (see worker.py:34-44)
+                gui.session.current_file_path = file_path
+                logger.debug(f"Current file path set to: {file_path}")
+
+                filename = os.path.basename(file_path)
+                anonymized_name = anonymize_filename(file_path)
+                # Show overall file progress (filename shown separately in current_file_label)
+                update_ui_safely(
+                    gui.root,
+                    lambda idx=global_file_index, total=total_files_in_queue: (
+                        gui.status_label.config(text=f"File {idx}/{total}")
+                    ),
+                )
+                update_ui_safely(gui.root, reset_ui_callback)  # Reset UI elements for the new file
+
+                # Calculate output path using the new helper (skip for ANALYZE operations)
+                output_path = None
+                overwrite = False
+                delete_original = False
+                if queue_item.operation_type == OperationType.CONVERT:
+                    try:
+                        output_path_obj, overwrite, delete_original = calculate_output_path(
+                            input_path=file_path,
+                            output_mode=queue_item.output_mode,
+                            suffix=queue_item.output_suffix or config.default_suffix,
+                            output_folder=queue_item.output_folder,
+                            source_folder=queue_item.source_path if queue_item.is_folder else None,
+                        )
+                        output_path = str(output_path_obj)
+                    except Exception as e:
+                        logger.exception(f"Error calculating output path for {anonymized_name}")
+                        error_msg = f"Failed to calculate output path: {e!s}"
+                        file_event_callback(filename, "failed", {"message": error_msg, "type": "path_error"})
+                        queue_item.processed_files += 1
+                        queue_item.files_failed += 1
+                        queue_item.last_error = error_msg
+                        _update_file_status(queue_item, file_index, QueueItemStatus.ERROR, error_msg)
+                        queue_status_callback(
+                            queue_item.id,
+                            QueueItemStatus.CONVERTING,
+                            queue_item.processed_files,
+                            queue_item.total_files,
+                        )
+                        continue
+
+                # Check eligibility with new scanner signature (skip for ANALYZE operations)
+                if queue_item.operation_type == OperationType.CONVERT and output_path is not None:
+                    try:
+                        needs_conversion, reason, video_info = scan_video_needs_conversion(
+                            input_video_path=file_path,
+                            output_path=output_path,
+                            overwrite=overwrite,
+                            video_info_cache=video_info_cache,
+                        )
+                    except Exception as e:
+                        logger.exception(f"Error during eligibility scan for {anonymized_name}")
+                        error_msg = f"Scan error: {e!s}"
+                        file_event_callback(filename, "failed", {"message": error_msg, "type": "scan_error"})
+                        queue_item.processed_files += 1
+                        queue_item.files_failed += 1
+                        queue_item.last_error = error_msg
+                        _update_file_status(queue_item, file_index, QueueItemStatus.ERROR, error_msg)
+                        queue_status_callback(
+                            queue_item.id,
+                            QueueItemStatus.CONVERTING,
+                            queue_item.processed_files,
+                            queue_item.total_files,
+                        )
+                        continue
+                else:
+                    # ANALYZE operation - always "needs conversion" (really means "needs analysis")
+                    needs_conversion = True
+                    reason = ""
+
+                    try:
+                        video_info = video_info_cache.get(file_path) or get_video_info(file_path)
+                        if video_info and file_path not in video_info_cache:
+                            video_info_cache[file_path] = video_info
+                    except Exception as e:
+                        logger.exception(f"Error getting video info for ANALYZE operation: {anonymized_name}")
+                        error_msg = f"Video info error: {e!s}"
+                        file_event_callback(filename, "failed", {"message": error_msg, "type": "video_info_error"})
+                        queue_item.processed_files += 1
+                        queue_item.files_failed += 1
+                        queue_item.last_error = error_msg
+                        _update_file_status(queue_item, file_index, QueueItemStatus.ERROR, error_msg)
+                        queue_status_callback(
+                            queue_item.id,
+                            QueueItemStatus.CONVERTING,
+                            queue_item.processed_files,
+                            queue_item.total_files,
+                        )
+                        continue
+
+                if queue_item.operation_type == OperationType.CONVERT and not needs_conversion:
+                    # File doesn't need conversion, skip it
+                    filename_skip = os.path.basename(file_path)
+                    file_event_callback(filename_skip, "skipped", reason)
+
+                    # Check if skipped due to resolution (thread-safe)
+                    if "Below minimum resolution" in reason:
+
+                        def update_low_res_skip(fn=filename_skip):
+                            gui.session.skipped_low_resolution_count += 1
+                            gui.session.skipped_low_resolution_files.append(fn)
+
+                        update_ui_safely(gui.root, update_low_res_skip)
+
                     queue_item.processed_files += 1
                     queue_item.files_skipped += 1
                     _update_file_status(queue_item, file_index, QueueItemStatus.COMPLETED)
                     queue_status_callback(
                         queue_item.id, QueueItemStatus.CONVERTING, queue_item.processed_files, queue_item.total_files
                     )
+                    # Update analysis tree - "done" for already-converted, "skip" for others
+                    reason_lower = reason.lower() if reason else ""
+                    tree_status = "done" if "already converted" in reason_lower else "skip"
                     update_ui_safely(
                         gui.root,
                         lambda fp=file_path, s=tree_status: gui.update_analysis_tree_for_completed_file(fp, s)
                     )
                     continue
 
-            current_time = time.time()
-            update_ui_safely(gui.root, lambda t=current_time: setattr(gui.session, "current_file_start_time", t))
-            update_ui_safely(gui.root, lambda: setattr(gui.session, "current_file_encoding_start_time", None))
-            update_ui_safely(
-                gui.root, elapsed_time_callback, gui.session.current_file_start_time
-            )  # Start timer UI updates
-            update_ui_safely(gui.root, lambda: setattr(gui.session, "current_process_info", None))  # Reset PID info
+                # File needs conversion - proceed with processing
+                original_size = 0
+                input_vcodec = "?"
+                input_acodec = "?"
+                input_duration = 0.0
+                input_width = None
+                input_height = None
+                input_bitrate_kbps = None
+                input_audio_streams = []
+                output_acodec = "?"  # Initialize output audio codec
 
-            # --- Determine Hardware Decoder ---
-            hw_decoder = None
-            if hw_decode_enabled_value[0] and video_info:
-                source_codec = get_video_codec_from_info(video_info)
-                if source_codec:
-                    hw_decoder = get_hw_decoder_for_codec(source_codec)
-                    if hw_decoder:
-                        logger.info(f"Using hardware decoder {hw_decoder} for {source_codec}")
-                    else:
-                        logger.debug(f"No hardware decoder available for {source_codec}")
-
-            # --- Process Video ---
-            process_successful = False
-            output_file_path = None
-            elapsed_time_file = 0
-            output_size = 0
-            final_crf = None
-            final_vmaf = None
-            final_vmaf_target = None
-
-            try:
-                if queue_item.operation_type == OperationType.ANALYZE:
-                    # ANALYZE operation: Run CRF search only, no encoding
-
-                    # Check for cached status that should skip analysis
-                    index = get_history_index()
-                    cached_record = index.lookup_file(file_path)
-                    if cached_record:
-                        # Skip CONVERTED files - no point analyzing, conversion history is
-                        # valuable (converted_verdict_applies also covers the replace-mode
-                        # output at the input path, which would otherwise be CRF-searched)
-                        if cached_record.status == FileStatus.CONVERTED:
-                            if converted_verdict_applies(cached_record, file_path):
-                                logger.info(f"Skipping {anonymized_name} - already converted")
-                                file_event_callback(filename, "skipped", "Already converted")
-                                queue_item.files_skipped += 1
-                                _update_file_status(queue_item, file_index, QueueItemStatus.COMPLETED)
-                                queue_item.processed_files += 1
-                                queue_status_callback(
-                                    queue_item.id,
-                                    QueueItemStatus.CONVERTING,
-                                    queue_item.processed_files,
-                                    queue_item.total_files,
-                                )
-                                continue  # Skip to next file
-                            # File changed since conversion - needs re-conversion, not just analysis
-                            logger.info(f"File {anonymized_name} changed since conversion, re-analyzing")
-
-                        # Skip NOT_WORTHWHILE files - already determined conversion isn't beneficial
-                        elif cached_record.status == FileStatus.NOT_WORTHWHILE:
-                            if is_file_unchanged(cached_record, file_path):
-                                logger.info(f"Skipping {anonymized_name} - previously marked not worthwhile")
-                                file_event_callback(
-                                    filename, "skipped", cached_record.skip_reason or "Previously marked not worthwhile"
-                                )
-                                queue_item.files_skipped += 1
-                                _update_file_status(queue_item, file_index, QueueItemStatus.COMPLETED)
-                                queue_item.processed_files += 1
-                                queue_status_callback(
-                                    queue_item.id,
-                                    QueueItemStatus.CONVERTING,
-                                    queue_item.processed_files,
-                                    queue_item.total_files,
-                                )
-                                continue  # Skip to next file
-                            logger.info(f"File {anonymized_name} changed since NOT_WORTHWHILE analysis, re-analyzing")
-
-                        # Skip ANALYZED files - already have Layer 2 data (CRF search complete)
-                        elif cached_record.status == FileStatus.ANALYZED:
-                            if is_file_unchanged(cached_record, file_path):
-                                logger.info(f"Skipping {anonymized_name} - already analyzed")
-                                file_event_callback(filename, "skipped", "Already analyzed")
-                                queue_item.files_skipped += 1
-                                _update_file_status(queue_item, file_index, QueueItemStatus.COMPLETED)
-                                queue_item.processed_files += 1
-                                queue_status_callback(
-                                    queue_item.id,
-                                    QueueItemStatus.CONVERTING,
-                                    queue_item.processed_files,
-                                    queue_item.total_files,
-                                )
-                                continue  # Skip to next file
-                            logger.info(f"File {anonymized_name} changed since analysis, re-analyzing")
-
-                    logger.info(f"Running CRF search (analysis only) for {anonymized_name}")
-                    wrapper = AbAv1Wrapper()
-                    crf_search_start = time.time()  # Track timing for both success and NOT_WORTHWHILE
-
-                    def progress_cb(progress_pct, message, fname=filename):
-                        # Report progress as quality detection progress
-                        event = ProgressEvent(
-                            progress_quality=progress_pct, progress_encoding=0.0, phase="crf-search", message=message
-                        )
-                        file_event_callback(fname, "progress", event)
-
+                # --- Extract Info & Update UI ---
+                if video_info:
                     try:
-                        crf_result = wrapper.crf_search(
-                            input_path=file_path,
-                            vmaf_target=DEFAULT_VMAF_TARGET,
-                            preset=DEFAULT_ENCODING_PRESET,
-                            progress_callback=progress_cb,
-                            stop_event=stop_event,
-                            hw_decoder=hw_decoder,
-                        )
+                        meta = extract_video_metadata(video_info)
+                        input_vcodec = (meta.video_codec or "?").upper()
+                        # Get audio codec from first stream (for display purposes)
+                        input_acodec = (meta.audio_streams[0].codec if meta.audio_streams else "?").upper()
+                        input_width = meta.width
+                        input_height = meta.height
+                        input_duration = meta.duration_sec or 0.0
+                        original_size = meta.file_size_bytes or 0
+                        input_bitrate_kbps = meta.bitrate_kbps
+                        input_audio_streams = meta.audio_streams
 
-                        # Extract results from crf_search
-                        final_crf = crf_result.get("best_crf")
-                        final_vmaf = crf_result.get("best_vmaf")
-                        final_vmaf_target = crf_result.get("vmaf_target_used")
-                        predicted_output_size = crf_result.get("predicted_output_size")
-                        predicted_size_reduction = crf_result.get("predicted_size_reduction")
-                        crf_search_time = crf_result.get("crf_search_time_sec")
+                        update_ui_safely(gui.root, lambda os=original_size: setattr(gui.session, "last_input_size", os))
+                        output_acodec = input_acodec  # Default output codec
+                    except Exception:
+                        logger.exception(f"Error extracting details from video_info for {anonymized_name}")
+                        update_ui_safely(gui.root, lambda: setattr(gui.session, "last_input_size", None))
+                        input_duration = 0.0
+                else:
+                    logger.warning(f"Cannot get pre-conversion info for {anonymized_name}.")
+                    update_ui_safely(gui.root, lambda: setattr(gui.session, "last_input_size", None))
+                    input_duration = 0.0
 
-                        # Update history index with Layer 2 data
-                        record = _create_file_record(
-                            file_path,
-                            anonymize_history_value[0],
-                            FileStatus.ANALYZED,
-                            original_size,
-                            input_duration,
-                            input_vcodec,
-                            input_width,
-                            input_height,
-                            bitrate_kbps=input_bitrate_kbps,
-                            audio_streams=input_audio_streams,
-                            crf_search_time_sec=crf_search_time,
-                            final_crf=final_crf,
-                            final_vmaf=final_vmaf,
-                            vmaf_target=final_vmaf_target,
-                            predicted_output_size=predicted_output_size,
-                            predicted_size_reduction=predicted_size_reduction,
+                # --- Duplicate Short-Circuit (ADR-001) ---
+                # A physical file already decided under another path must not be re-processed:
+                # skip on CONVERTED / NOT_WORTHWHILE (and on ANALYZED for ANALYZE operations).
+                # An ANALYZED verdict on a CONVERT operation falls through instead - the alias
+                # written here carries the Layer-2 data, so process_video reuses the cached CRF.
+                index = get_history_index()
+                verdict = _find_duplicate_verdict(index, file_path, original_size, input_duration)
+                if verdict is not None:
+                    if verdict.duplicate_of is None:
+                        _persist_duplicate_alias(
+                            index, verdict, file_path, video_info, anonymize_history_value[0] or False
                         )
-                        _save_file_record(record)
-
-                        # Report completion via callback
-                        file_event_callback(
-                            filename,
-                            "completed",
-                            {
-                                "message": f"Analysis complete (CRF {final_crf}, VMAF {final_vmaf:.2f})",
-                                "crf": final_crf,
-                                "vmaf": final_vmaf,
-                                "vmaf_target_used": final_vmaf_target,
-                            },
-                        )
-                        process_successful = True
-                        queue_item.files_succeeded += 1
+                    if verdict.status in (FileStatus.CONVERTED, FileStatus.NOT_WORTHWHILE) or (
+                        verdict.status == FileStatus.ANALYZED and queue_item.operation_type == OperationType.ANALYZE
+                    ):
+                        if verdict.status == FileStatus.CONVERTED:
+                            reason, tree_status = "Already converted (duplicate of another path)", "done"
+                        elif verdict.status == FileStatus.NOT_WORTHWHILE:
+                            reason, tree_status = "Not worth converting (duplicate of another path)", "skip"
+                        else:
+                            reason, tree_status = "Already analyzed (duplicate of another path)", "done"
+                        logger.info(f"Skipping {anonymized_name} - {reason}")
+                        file_event_callback(filename, "skipped", reason)
+                        queue_item.processed_files += 1
+                        queue_item.files_skipped += 1
                         _update_file_status(queue_item, file_index, QueueItemStatus.COMPLETED)
-                        logger.info(f"Analysis complete for {anonymized_name}: CRF {final_crf}, VMAF {final_vmaf:.2f}")
-
-                        # Update analysis tree now that history is saved
+                        queue_status_callback(
+                            queue_item.id,
+                            QueueItemStatus.CONVERTING,
+                            queue_item.processed_files,
+                            queue_item.total_files,
+                        )
                         update_ui_safely(
                             gui.root,
-                            lambda fp=file_path: gui.update_analysis_tree_for_completed_file(fp, "done")
+                            lambda fp=file_path, s=tree_status: gui.update_analysis_tree_for_completed_file(fp, s)
                         )
+                        continue
 
-                    except ConversionNotWorthwhileError as e:
-                        # CRF search failed at all VMAF targets - record as NOT_WORTHWHILE
-                        crf_search_elapsed = time.time() - crf_search_start
-                        logger.warning(f"Analysis showed conversion not worthwhile for {anonymized_name}: {e}")
+                current_time = time.time()
+                update_ui_safely(gui.root, lambda t=current_time: setattr(gui.session, "current_file_start_time", t))
+                update_ui_safely(gui.root, lambda: setattr(gui.session, "current_file_encoding_start_time", None))
+                update_ui_safely(
+                    gui.root, elapsed_time_callback, gui.session.current_file_start_time
+                )  # Start timer UI updates
+                update_ui_safely(gui.root, lambda: setattr(gui.session, "current_process_info", None))  # Reset PID info
 
-                        # Record NOT_WORTHWHILE to history BEFORE callback (so folder aggregates are correct)
+                # --- Determine Hardware Decoder ---
+                hw_decoder = None
+                if hw_decode_enabled_value[0] and video_info:
+                    source_codec = get_video_codec_from_info(video_info)
+                    if source_codec:
+                        hw_decoder = get_hw_decoder_for_codec(source_codec)
+                        if hw_decoder:
+                            logger.info(f"Using hardware decoder {hw_decoder} for {source_codec}")
+                        else:
+                            logger.debug(f"No hardware decoder available for {source_codec}")
+
+                # --- Process Video ---
+                process_successful = False
+                output_file_path = None
+                elapsed_time_file = 0
+                output_size = 0
+                final_crf = None
+                final_vmaf = None
+                final_vmaf_target = None
+
+                try:
+                    if queue_item.operation_type == OperationType.ANALYZE:
+                        # ANALYZE operation: Run CRF search only, no encoding
+
+                        # Check for cached status that should skip analysis
+                        index = get_history_index()
+                        cached_record = index.lookup_file(file_path)
+                        if cached_record:
+                            # Skip CONVERTED files - no point analyzing, conversion history is
+                            # valuable (converted_verdict_applies also covers the replace-mode
+                            # output at the input path, which would otherwise be CRF-searched)
+                            if cached_record.status == FileStatus.CONVERTED:
+                                if converted_verdict_applies(cached_record, file_path):
+                                    logger.info(f"Skipping {anonymized_name} - already converted")
+                                    file_event_callback(filename, "skipped", "Already converted")
+                                    queue_item.files_skipped += 1
+                                    _update_file_status(queue_item, file_index, QueueItemStatus.COMPLETED)
+                                    queue_item.processed_files += 1
+                                    queue_status_callback(
+                                        queue_item.id,
+                                        QueueItemStatus.CONVERTING,
+                                        queue_item.processed_files,
+                                        queue_item.total_files,
+                                    )
+                                    continue  # Skip to next file
+                                # File changed since conversion - needs re-conversion, not just analysis
+                                logger.info(f"File {anonymized_name} changed since conversion, re-analyzing")
+
+                            # Skip NOT_WORTHWHILE files - already determined conversion isn't beneficial
+                            elif cached_record.status == FileStatus.NOT_WORTHWHILE:
+                                if is_file_unchanged(cached_record, file_path):
+                                    logger.info(f"Skipping {anonymized_name} - previously marked not worthwhile")
+                                    file_event_callback(
+                                        filename,
+                                        "skipped",
+                                        cached_record.skip_reason or "Previously marked not worthwhile",
+                                    )
+                                    queue_item.files_skipped += 1
+                                    _update_file_status(queue_item, file_index, QueueItemStatus.COMPLETED)
+                                    queue_item.processed_files += 1
+                                    queue_status_callback(
+                                        queue_item.id,
+                                        QueueItemStatus.CONVERTING,
+                                        queue_item.processed_files,
+                                        queue_item.total_files,
+                                    )
+                                    continue  # Skip to next file
+                                logger.info(
+                                    f"File {anonymized_name} changed since NOT_WORTHWHILE analysis, re-analyzing"
+                                )
+
+                            # Skip ANALYZED files - already have Layer 2 data (CRF search complete)
+                            elif cached_record.status == FileStatus.ANALYZED:
+                                if is_file_unchanged(cached_record, file_path):
+                                    logger.info(f"Skipping {anonymized_name} - already analyzed")
+                                    file_event_callback(filename, "skipped", "Already analyzed")
+                                    queue_item.files_skipped += 1
+                                    _update_file_status(queue_item, file_index, QueueItemStatus.COMPLETED)
+                                    queue_item.processed_files += 1
+                                    queue_status_callback(
+                                        queue_item.id,
+                                        QueueItemStatus.CONVERTING,
+                                        queue_item.processed_files,
+                                        queue_item.total_files,
+                                    )
+                                    continue  # Skip to next file
+                                logger.info(f"File {anonymized_name} changed since analysis, re-analyzing")
+
+                        logger.info(f"Running CRF search (analysis only) for {anonymized_name}")
+                        wrapper = AbAv1Wrapper()
+                        crf_search_start = time.time()  # Track timing for both success and NOT_WORTHWHILE
+
+                        def progress_cb(progress_pct, message, fname=filename):
+                            # Report progress as quality detection progress
+                            event = ProgressEvent(
+                                progress_quality=progress_pct,
+                                progress_encoding=0.0,
+                                phase="crf-search",
+                                message=message,
+                            )
+                            file_event_callback(fname, "progress", event)
+
+                        try:
+                            crf_result = wrapper.crf_search(
+                                input_path=file_path,
+                                vmaf_target=DEFAULT_VMAF_TARGET,
+                                preset=DEFAULT_ENCODING_PRESET,
+                                progress_callback=progress_cb,
+                                stop_event=stop_event,
+                                hw_decoder=hw_decoder,
+                            )
+
+                            # Extract results from crf_search
+                            final_crf = crf_result.get("best_crf")
+                            final_vmaf = crf_result.get("best_vmaf")
+                            final_vmaf_target = crf_result.get("vmaf_target_used")
+                            predicted_output_size = crf_result.get("predicted_output_size")
+                            predicted_size_reduction = crf_result.get("predicted_size_reduction")
+                            crf_search_time = crf_result.get("crf_search_time_sec")
+
+                            # Update history index with Layer 2 data
+                            record = _create_file_record(
+                                file_path,
+                                anonymize_history_value[0],
+                                FileStatus.ANALYZED,
+                                original_size,
+                                input_duration,
+                                input_vcodec,
+                                input_width,
+                                input_height,
+                                bitrate_kbps=input_bitrate_kbps,
+                                audio_streams=input_audio_streams,
+                                crf_search_time_sec=crf_search_time,
+                                final_crf=final_crf,
+                                final_vmaf=final_vmaf,
+                                vmaf_target=final_vmaf_target,
+                                predicted_output_size=predicted_output_size,
+                                predicted_size_reduction=predicted_size_reduction,
+                            )
+                            _save_file_record(record)
+
+                            # Report completion via callback
+                            file_event_callback(
+                                filename,
+                                "completed",
+                                {
+                                    "message": f"Analysis complete (CRF {final_crf}, VMAF {final_vmaf:.2f})",
+                                    "crf": final_crf,
+                                    "vmaf": final_vmaf,
+                                    "vmaf_target_used": final_vmaf_target,
+                                },
+                            )
+                            process_successful = True
+                            queue_item.files_succeeded += 1
+                            _update_file_status(queue_item, file_index, QueueItemStatus.COMPLETED)
+                            logger.info(
+                                f"Analysis complete for {anonymized_name}: CRF {final_crf}, VMAF {final_vmaf:.2f}"
+                            )
+
+                            # Update analysis tree now that history is saved
+                            update_ui_safely(
+                                gui.root,
+                                lambda fp=file_path: gui.update_analysis_tree_for_completed_file(fp, "done")
+                            )
+
+                        except ConversionNotWorthwhileError as e:
+                            # CRF search failed at all VMAF targets - record as NOT_WORTHWHILE
+                            crf_search_elapsed = time.time() - crf_search_start
+                            logger.warning(f"Analysis showed conversion not worthwhile for {anonymized_name}: {e}")
+
+                            # Record NOT_WORTHWHILE to history BEFORE callback (so folder aggregates are correct)
+                            record = _create_file_record(
+                                file_path,
+                                anonymize_history_value[0],
+                                FileStatus.NOT_WORTHWHILE,
+                                original_size,
+                                input_duration,
+                                input_vcodec,
+                                input_width,
+                                input_height,
+                                bitrate_kbps=input_bitrate_kbps,
+                                audio_streams=input_audio_streams,
+                                crf_search_time_sec=crf_search_elapsed,
+                                vmaf_target_attempted=DEFAULT_VMAF_TARGET,
+                                min_vmaf_attempted=MIN_VMAF_FALLBACK_TARGET,
+                                skip_reason=str(e),
+                            )
+                            _save_file_record(record)
+
+                            file_event_callback(
+                                filename,
+                                "skipped_not_worth",
+                                {
+                                    "message": str(e),
+                                    "original_size": original_size,
+                                    "min_vmaf_attempted": MIN_VMAF_FALLBACK_TARGET,
+                                },
+                            )
+                            queue_item.files_skipped += 1
+                            _update_file_status(queue_item, file_index, QueueItemStatus.COMPLETED)
+
+                            # Update analysis tree now that history is saved
+                            update_ui_safely(
+                                gui.root,
+                                lambda fp=file_path: gui.update_analysis_tree_for_completed_file(fp, "skip")
+                            )
+
+                            process_successful = False
+
+                    elif output_path is not None:
+                        # CONVERT operation: Full conversion with process_video
+                        result_tuple = process_video(
+                            video_path=file_path,
+                            output_path=output_path,
+                            overwrite=overwrite,
+                            delete_original=delete_original,
+                            convert_audio=config.convert_audio,
+                            audio_codec=config.audio_codec,
+                            file_info_callback=file_event_callback,
+                            pid_callback=lambda pid, path=file_path: pid_storage_callback(gui, pid, path),
+                            total_duration_seconds=input_duration,
+                            hw_decoder=hw_decoder,
+                        )
+                        if result_tuple:
+                            # Unpack tuple including timing breakdown
+                            (
+                                output_file_path,
+                                elapsed_time_file,
+                                _,
+                                output_size,
+                                final_crf,
+                                final_vmaf,
+                                final_vmaf_target,
+                                crf_search_time_file,
+                                encoding_time_file,
+                            ) = result_tuple
+                            process_successful = True
+                            update_ui_safely(
+                                gui.root, lambda os=output_size: setattr(gui.session, "last_output_size", os)
+                            )
+                            update_ui_safely(
+                                gui.root, lambda et=elapsed_time_file: setattr(gui.session, "last_elapsed_time", et)
+                            )
+                            # Determine final audio codec based on conversion settings
+                            if config.convert_audio and input_acodec.lower() not in ["aac", "opus"]:
+                                output_acodec = config.audio_codec.lower()
+                            # else: output_acodec remains input_acodec (set earlier)
+                        else:
+                            # If process_video returns None, it means failure was reported via callback
+                            update_ui_safely(gui.root, lambda: setattr(gui.session, "last_output_size", None))
+                            update_ui_safely(gui.root, lambda: setattr(gui.session, "last_elapsed_time", None))
+                            process_successful = False  # Ensure state reflects failure
+
+                except Exception as e:
+                    logger.exception(f"Critical error during processing for {anonymized_name}")
+                    # Dispatch a generic failure
+                    error_msg = f"Internal processing error: {e!s}"
+                    file_event_callback(filename, "failed", {"message": error_msg, "type": "processing_crash"})
+                    process_successful = False
+                    queue_item.files_failed += 1
+                    queue_item.last_error = error_msg
+                    _update_file_status(queue_item, file_index, QueueItemStatus.ERROR, error_msg)
+                    update_ui_safely(gui.root, lambda: setattr(gui.session, "last_output_size", None))
+                    update_ui_safely(gui.root, lambda: setattr(gui.session, "last_elapsed_time", None))
+
+                # --- Post-processing & History ---
+                update_ui_safely(
+                    gui.root, lambda: setattr(gui.session, "processed_files", gui.session.processed_files + 1)
+                )
+
+                # Update queue item progress
+                queue_item.processed_files += 1
+                queue_status_callback(
+                    queue_item.id, QueueItemStatus.CONVERTING, queue_item.processed_files, queue_item.total_files
+                )
+
+                if process_successful:
+                    update_ui_safely(
+                        gui.root,
+                        lambda: setattr(gui.session, "successful_conversions", gui.session.successful_conversions + 1),
+                    )
+                    # Track successful file outcome
+                    if queue_item.operation_type == OperationType.CONVERT:
+                        queue_item.files_succeeded += 1
+                        _update_file_status(queue_item, file_index, QueueItemStatus.COMPLETED)
+                    # Note: For ANALYZE operations, files_succeeded is incremented earlier
+                    # Note: The "completed" callback is already dispatched by the wrapper (ab_av1/wrapper.py)
+                    # before returning, so we don't call it again here to avoid double-counting statistics.
+                    # However, we DO need to update the totals here because the wrapper's callback fires
+                    # before we have elapsed_time available (it's calculated after process_video returns).
+                    if original_size and output_size and elapsed_time_file:
+
+                        def update_totals_from_worker(
+                            inp_size=original_size, out_size=output_size, elapsed=elapsed_time_file
+                        ):
+                            gui.session.total_input_bytes_success += inp_size
+                            gui.session.total_output_bytes_success += out_size
+                            gui.session.total_time_success += elapsed
+
+                        update_ui_safely(gui.root, update_totals_from_worker)
+
+                    # Only save CONVERTED record for CONVERT operations
+                    # (ANALYZE operations save their ANALYZED record earlier in the flow)
+                    if queue_item.operation_type == OperationType.CONVERT:
+                        try:  # Record to History Index
+                            record = _create_file_record(
+                                file_path,
+                                anonymize_history_value[0],
+                                FileStatus.CONVERTED,
+                                original_size,
+                                input_duration,
+                                input_vcodec,
+                                input_width,
+                                input_height,
+                                bitrate_kbps=input_bitrate_kbps,
+                                audio_streams=input_audio_streams,
+                                output_path=output_file_path,
+                                output_size=output_size,
+                                crf_search_time_sec=crf_search_time_file,
+                                encoding_time_sec=encoding_time_file,
+                                final_crf=final_crf,
+                                final_vmaf=final_vmaf,
+                                vmaf_target=final_vmaf_target if final_vmaf_target is not None else DEFAULT_VMAF_TARGET,
+                                output_acodec=output_acodec,
+                            )
+                            _save_file_record(record)
+                            # Update analysis tree now that history is saved
+                            update_ui_safely(
+                                gui.root,
+                                lambda fp=file_path: gui.update_analysis_tree_for_completed_file(fp, "done")
+                            )
+                        except Exception:
+                            logger.exception(f"Failed to record history for {anonymized_name}")
+                # Check if this was a NOT_WORTHWHILE skip and record to history
+                elif gui.session.last_skip_reason:
+                    queue_item.files_skipped += 1
+                    _update_file_status(queue_item, file_index, QueueItemStatus.COMPLETED)
+
+                    # Capture skip data and timing before clearing
+                    skip_reason = gui.session.last_skip_reason
+                    min_vmaf_attempted = gui.session.last_min_vmaf_attempted
+                    # Calculate elapsed time for CRF search attempt (set at line 477)
+                    file_start = gui.session.current_file_start_time
+                    crf_search_elapsed = time.time() - file_start if file_start else None
+
+                    # Clear skip state (safe to do synchronously per THREAD SAFETY NOTE)
+                    gui.session.last_skip_reason = None
+                    gui.session.last_min_vmaf_attempted = None
+
+                    try:  # Record NOT_WORTHWHILE to History Index
                         record = _create_file_record(
                             file_path,
                             anonymize_history_value[0],
@@ -796,237 +1005,71 @@ def sequential_conversion_worker(
                             audio_streams=input_audio_streams,
                             crf_search_time_sec=crf_search_elapsed,
                             vmaf_target_attempted=DEFAULT_VMAF_TARGET,
-                            min_vmaf_attempted=MIN_VMAF_FALLBACK_TARGET,
-                            skip_reason=str(e),
+                            min_vmaf_attempted=min_vmaf_attempted,
+                            skip_reason=skip_reason,
                         )
                         _save_file_record(record)
-
-                        file_event_callback(
-                            filename,
-                            "skipped_not_worth",
-                            {
-                                "message": str(e),
-                                "original_size": original_size,
-                                "min_vmaf_attempted": MIN_VMAF_FALLBACK_TARGET,
-                            },
-                        )
-                        queue_item.files_skipped += 1
-                        _update_file_status(queue_item, file_index, QueueItemStatus.COMPLETED)
-
+                        logger.info(f"Recorded NOT_WORTHWHILE status to history for {anonymized_name}")
                         # Update analysis tree now that history is saved
                         update_ui_safely(
                             gui.root,
                             lambda fp=file_path: gui.update_analysis_tree_for_completed_file(fp, "skip")
                         )
-
-                        process_successful = False
-
-                elif output_path is not None:
-                    # CONVERT operation: Full conversion with process_video
-                    result_tuple = process_video(
-                        video_path=file_path,
-                        output_path=output_path,
-                        overwrite=overwrite,
-                        delete_original=delete_original,
-                        convert_audio=config.convert_audio,
-                        audio_codec=config.audio_codec,
-                        file_info_callback=file_event_callback,
-                        pid_callback=lambda pid, path=file_path: pid_storage_callback(gui, pid, path),
-                        total_duration_seconds=input_duration,
-                        hw_decoder=hw_decoder,
-                    )
-                    if result_tuple:
-                        # Unpack tuple including timing breakdown
-                        (
-                            output_file_path,
-                            elapsed_time_file,
-                            _,
-                            output_size,
-                            final_crf,
-                            final_vmaf,
-                            final_vmaf_target,
-                            crf_search_time_file,
-                            encoding_time_file,
-                        ) = result_tuple
-                        process_successful = True
-                        update_ui_safely(gui.root, lambda os=output_size: setattr(gui.session, "last_output_size", os))
-                        update_ui_safely(
-                            gui.root, lambda et=elapsed_time_file: setattr(gui.session, "last_elapsed_time", et)
-                        )
-                        # Determine final audio codec based on conversion settings
-                        if config.convert_audio and input_acodec.lower() not in ["aac", "opus"]:
-                            output_acodec = config.audio_codec.lower()
-                        # else: output_acodec remains input_acodec (set earlier)
-                    else:
-                        # If process_video returns None, it means failure was reported via callback
-                        update_ui_safely(gui.root, lambda: setattr(gui.session, "last_output_size", None))
-                        update_ui_safely(gui.root, lambda: setattr(gui.session, "last_elapsed_time", None))
-                        process_successful = False  # Ensure state reflects failure
-
-            except Exception as e:
-                logger.exception(f"Critical error during processing for {anonymized_name}")
-                # Dispatch a generic failure
-                error_msg = f"Internal processing error: {e!s}"
-                file_event_callback(filename, "failed", {"message": error_msg, "type": "processing_crash"})
-                process_successful = False
-                queue_item.files_failed += 1
-                queue_item.last_error = error_msg
-                _update_file_status(queue_item, file_index, QueueItemStatus.ERROR, error_msg)
-                update_ui_safely(gui.root, lambda: setattr(gui.session, "last_output_size", None))
-                update_ui_safely(gui.root, lambda: setattr(gui.session, "last_elapsed_time", None))
-
-            # --- Post-processing & History ---
-            update_ui_safely(gui.root, lambda: setattr(gui.session, "processed_files", gui.session.processed_files + 1))
-
-            # Update queue item progress
-            queue_item.processed_files += 1
-            queue_status_callback(
-                queue_item.id, QueueItemStatus.CONVERTING, queue_item.processed_files, queue_item.total_files
-            )
-
-            if process_successful:
-                update_ui_safely(
-                    gui.root,
-                    lambda: setattr(gui.session, "successful_conversions", gui.session.successful_conversions + 1),
-                )
-                # Track successful file outcome
-                if queue_item.operation_type == OperationType.CONVERT:
-                    queue_item.files_succeeded += 1
-                    _update_file_status(queue_item, file_index, QueueItemStatus.COMPLETED)
-                # Note: For ANALYZE operations, files_succeeded is incremented earlier
-                # Note: The "completed" callback is already dispatched by the wrapper (ab_av1/wrapper.py)
-                # before returning, so we don't call it again here to avoid double-counting statistics.
-                # However, we DO need to update the totals here because the wrapper's callback fires
-                # before we have elapsed_time available (it's calculated after process_video returns).
-                if original_size and output_size and elapsed_time_file:
-
-                    def update_totals_from_worker(
-                        inp_size=original_size, out_size=output_size, elapsed=elapsed_time_file
-                    ):
-                        gui.session.total_input_bytes_success += inp_size
-                        gui.session.total_output_bytes_success += out_size
-                        gui.session.total_time_success += elapsed
-
-                    update_ui_safely(gui.root, update_totals_from_worker)
-
-                # Only save CONVERTED record for CONVERT operations
-                # (ANALYZE operations save their ANALYZED record earlier in the flow)
-                if queue_item.operation_type == OperationType.CONVERT:
-                    try:  # Record to History Index
-                        record = _create_file_record(
-                            file_path,
-                            anonymize_history_value[0],
-                            FileStatus.CONVERTED,
-                            original_size,
-                            input_duration,
-                            input_vcodec,
-                            input_width,
-                            input_height,
-                            bitrate_kbps=input_bitrate_kbps,
-                            audio_streams=input_audio_streams,
-                            output_path=output_file_path,
-                            output_size=output_size,
-                            crf_search_time_sec=crf_search_time_file,
-                            encoding_time_sec=encoding_time_file,
-                            final_crf=final_crf,
-                            final_vmaf=final_vmaf,
-                            vmaf_target=final_vmaf_target if final_vmaf_target is not None else DEFAULT_VMAF_TARGET,
-                            output_acodec=output_acodec,
-                        )
-                        _save_file_record(record)
-                        # Update analysis tree now that history is saved
-                        update_ui_safely(
-                            gui.root,
-                            lambda fp=file_path: gui.update_analysis_tree_for_completed_file(fp, "done")
-                        )
                     except Exception:
-                        logger.exception(f"Failed to record history for {anonymized_name}")
-            # Check if this was a NOT_WORTHWHILE skip and record to history
-            elif gui.session.last_skip_reason:
-                queue_item.files_skipped += 1
-                _update_file_status(queue_item, file_index, QueueItemStatus.COMPLETED)
+                        logger.exception(f"Failed to record NOT_WORTHWHILE history for {anonymized_name}")
+                else:
+                    # process_video returned None due to error (not a NOT_WORTHWHILE skip)
+                    # The error was already reported via callback, but we need to track it in queue item
+                    queue_item.files_failed += 1
+                    error_msg = queue_item.last_error or "Processing failed (see logs for details)"
+                    if not queue_item.last_error:
+                        queue_item.last_error = error_msg
+                    _update_file_status(queue_item, file_index, QueueItemStatus.ERROR, error_msg)
 
-                # Capture skip data and timing before clearing
-                skip_reason = gui.session.last_skip_reason
-                min_vmaf_attempted = gui.session.last_min_vmaf_attempted
-                # Calculate elapsed time for CRF search attempt (set at line 477)
-                file_start = gui.session.current_file_start_time
-                crf_search_elapsed = time.time() - file_start if file_start else None
+                # Note: Original file deletion (for REPLACE mode) is handled by process_video()
 
-                # Clear skip state (safe to do synchronously per THREAD SAFETY NOTE)
-                gui.session.last_skip_reason = None
-                gui.session.last_min_vmaf_attempted = None
+                def update_status(ic=items_completed + 1, it=items_total):  # Capture loop variables
+                    base_status = f"Item {ic}/{it}"
+                    converted_msg = f" ({gui.session.successful_conversions} converted"
 
-                try:  # Record NOT_WORTHWHILE to History Index
-                    record = _create_file_record(
-                        file_path,
-                        anonymize_history_value[0],
-                        FileStatus.NOT_WORTHWHILE,
-                        original_size,
-                        input_duration,
-                        input_vcodec,
-                        input_width,
-                        input_height,
-                        bitrate_kbps=input_bitrate_kbps,
-                        audio_streams=input_audio_streams,
-                        crf_search_time_sec=crf_search_elapsed,
-                        vmaf_target_attempted=DEFAULT_VMAF_TARGET,
-                        min_vmaf_attempted=min_vmaf_attempted,
-                        skip_reason=skip_reason,
-                    )
-                    _save_file_record(record)
-                    logger.info(f"Recorded NOT_WORTHWHILE status to history for {anonymized_name}")
-                    # Update analysis tree now that history is saved
-                    update_ui_safely(
-                        gui.root,
-                        lambda fp=file_path: gui.update_analysis_tree_for_completed_file(fp, "skip")
-                    )
-                except Exception:
-                    logger.exception(f"Failed to record NOT_WORTHWHILE history for {anonymized_name}")
+                    # Show different skip categories
+                    if gui.session.skipped_not_worth_count > 0:
+                        converted_msg += f", {gui.session.skipped_not_worth_count} inefficient"
+
+                    if gui.session.skipped_low_resolution_count > 0:
+                        converted_msg += f", {gui.session.skipped_low_resolution_count} low-res"
+
+                    converted_msg += ")"
+
+                    # Only show errors if there are actual errors
+                    error_suffix = f" - {gui.session.error_count} errors" if gui.session.error_count > 0 else ""
+                    gui.status_label.config(text=f"{base_status}{converted_msg}{error_suffix}")
+
+                update_ui_safely(gui.root, update_status)
+
+            # Mark queue item as completed or stopped and increment counter
+            if stop_event.is_set() and queue_item.processed_files < queue_item.total_files:
+                # Stopped before completing all files
+                queue_item.status = QueueItemStatus.STOPPED
+                queue_status_callback(
+                    queue_item.id, QueueItemStatus.STOPPED, queue_item.processed_files, queue_item.total_files
+                )
             else:
-                # process_video returned None due to error (not a NOT_WORTHWHILE skip)
-                # The error was already reported via callback, but we need to track it in queue item
-                queue_item.files_failed += 1
-                error_msg = queue_item.last_error or "Processing failed (see logs for details)"
-                if not queue_item.last_error:
-                    queue_item.last_error = error_msg
-                _update_file_status(queue_item, file_index, QueueItemStatus.ERROR, error_msg)
+                # Completed all files (or stopped after completing all files)
+                queue_item.status = QueueItemStatus.COMPLETED
+                queue_status_callback(
+                    queue_item.id, QueueItemStatus.COMPLETED, queue_item.processed_files, queue_item.total_files
+                )
+            # Mandatory flush at the item boundary (issue #22): a completed or stopped
+            # queue item's records must reach disk regardless of the debounce interval.
+            get_history_index().save()
+            items_completed += 1
 
-            # Note: Original file deletion (for REPLACE mode) is handled by process_video()
-
-            def update_status(ic=items_completed + 1, it=items_total):  # Capture loop variables
-                base_status = f"Item {ic}/{it}"
-                converted_msg = f" ({gui.session.successful_conversions} converted"
-
-                # Show different skip categories
-                if gui.session.skipped_not_worth_count > 0:
-                    converted_msg += f", {gui.session.skipped_not_worth_count} inefficient"
-
-                if gui.session.skipped_low_resolution_count > 0:
-                    converted_msg += f", {gui.session.skipped_low_resolution_count} low-res"
-
-                converted_msg += ")"
-
-                # Only show errors if there are actual errors
-                error_suffix = f" - {gui.session.error_count} errors" if gui.session.error_count > 0 else ""
-                gui.status_label.config(text=f"{base_status}{converted_msg}{error_suffix}")
-
-            update_ui_safely(gui.root, update_status)
-
-        # Mark queue item as completed or stopped and increment counter
-        if stop_event.is_set() and queue_item.processed_files < queue_item.total_files:
-            # Stopped before completing all files
-            queue_item.status = QueueItemStatus.STOPPED
-            queue_status_callback(
-                queue_item.id, QueueItemStatus.STOPPED, queue_item.processed_files, queue_item.total_files
-            )
-        else:
-            # Completed all files (or stopped after completing all files)
-            queue_item.status = QueueItemStatus.COMPLETED
-            queue_status_callback(
-                queue_item.id, QueueItemStatus.COMPLETED, queue_item.processed_files, queue_item.total_files
-            )
-        items_completed += 1
+    finally:
+        # Mandatory flush on worker exit (issue #22): stop, crash, or normal
+        # completion must never lose an already-processed file's record to the
+        # save debounce.
+        get_history_index().save()
 
     # --- End of Processing Loop ---
     final_status_message = "Queue complete"

--- a/src/folder_analysis.py
+++ b/src/folder_analysis.py
@@ -252,101 +252,113 @@ def _analyze_file(
     video_info = get_video_info(file_path)
     meta = extract_video_metadata(video_info)
 
-    # A canonical CONVERTED record survives a size/mtime mismatch only while the file is
-    # plausibly its own output: in replace mode the file at that path IS the AV1 output,
-    # so changed stamps are the expected steady state (also preserved when the probe
-    # failed and the codec is unknown). A non-AV1 file cannot be our output - the path
-    # was replaced with new content, so the verdict is stale. Aliases (any status) and
-    # ANALYZED/NOT_WORTHWHILE verdicts likewise described content that no longer exists;
-    # all of these fall through and re-derive from the fresh ffprobe.
-    if cached and cached.status == FileStatus.CONVERTED and cached.duplicate_of is None:
-        if meta.video_codec is None or meta.is_av1:
-            # Update metadata while preserving conversion data
-            record = _update_existing_record_metadata(cached, file_size, file_mtime, meta, anonymize, file_path)
-            # Save updated record and return result based on existing status
-            index.upsert(record)
-            return _record_to_result(file_path, record, index)
-        logger.info("Converted file replaced with non-AV1 content, re-deriving record: %s", filename)
+    # The remaining lookup -> duplicate-check -> upsert sequence must be atomic: two
+    # parallel scan workers processing two copies of the same physical file could
+    # otherwise both pass find_better_duplicate before either upserts, producing two
+    # canonical records instead of one canonical plus one alias (issue #22). The
+    # ffprobe above deliberately stays outside the lock - probes can take seconds
+    # and must not serialize the other workers.
+    with index.transaction():
+        # Re-read under the lock: another writer may have updated this path meanwhile.
+        cached = index.get(path_hash)
 
-    # Duplicate detection: same physical file reached via a different path?
-    duplicate = index.find_better_duplicate(file_path, file_size, meta.duration_sec)
-    if duplicate is not None:
-        if meta.duration_sec is None:
-            # No duration -> find_better_duplicate could only match on filename+size (low
-            # confidence). Show the duplicate's status but don't persist a terminal one.
-            return _record_to_result(file_path, duplicate, index)
-        if duplicate.status in DECIDED_STATUSES:
-            # Source carries a decided result worth mirroring. Persist an alias keyed by THIS
-            # path so lookup_file(this_path) resolves to it and the copy isn't re-encoded.
-            record = create_alias_record(
-                duplicate,
-                cached.first_seen if cached else None,
-                file_path,
-                path_hash,
-                file_size,
-                file_mtime,
-                meta,
-                anonymize,
+        # A canonical CONVERTED record survives a size/mtime mismatch only while the file is
+        # plausibly its own output: in replace mode the file at that path IS the AV1 output,
+        # so changed stamps are the expected steady state (also preserved when the probe
+        # failed and the codec is unknown). A non-AV1 file cannot be our output - the path
+        # was replaced with new content, so the verdict is stale. Aliases (any status) and
+        # ANALYZED/NOT_WORTHWHILE verdicts likewise described content that no longer exists;
+        # all of these fall through and re-derive from the fresh ffprobe.
+        if cached and cached.status == FileStatus.CONVERTED and cached.duplicate_of is None:
+            if meta.video_codec is None or meta.is_av1:
+                # Update metadata while preserving conversion data
+                record = _update_existing_record_metadata(cached, file_size, file_mtime, meta, anonymize, file_path)
+                # Save updated record and return result based on existing status
+                index.upsert(record)
+                return _record_to_result(file_path, record, index)
+            logger.info("Converted file replaced with non-AV1 content, re-deriving record: %s", filename)
+
+        # Duplicate detection: same physical file reached via a different path?
+        duplicate = index.find_better_duplicate(file_path, file_size, meta.duration_sec)
+        if duplicate is not None:
+            if meta.duration_sec is None:
+                # No duration -> find_better_duplicate could only match on filename+size (low
+                # confidence). Show the duplicate's status but don't persist a terminal one.
+                return _record_to_result(file_path, duplicate, index)
+            if duplicate.status in DECIDED_STATUSES:
+                # Source carries a decided result worth mirroring. Persist an alias keyed by THIS
+                # path so lookup_file(this_path) resolves to it and the copy isn't re-encoded.
+                record = create_alias_record(
+                    duplicate,
+                    cached.first_seen if cached else None,
+                    file_path,
+                    path_hash,
+                    file_size,
+                    file_mtime,
+                    meta,
+                    anonymize,
+                )
+                logger.debug("Aliased %s record to new path %s (duplicate detection)", duplicate.status, filename)
+                index.upsert(record)
+                return _record_to_result(file_path, record, index)
+            # Duplicate is only SCANNED - nothing decided to mirror; fall through and create a
+            # fresh SCANNED record for this path below.
+
+        # New file or previously SCANNED - create new SCANNED record
+        record = _create_scanned_record(file_path, path_hash, file_size, file_mtime, video_info, anonymize)
+
+        # Check for skip conditions
+        skip_status, skip_detail = _check_skip_conditions(record, video_info)
+        if skip_status:
+            record.skip_reason = skip_detail
+            index.upsert(record)
+            return FileAnalysisResult(
+                path=file_path,
+                path_hash=path_hash,
+                status=skip_status,
+                file_size_bytes=file_size,
+                video_codec=record.video_codec,
+                resolution=f"{record.width}x{record.height}" if record.width and record.height else None,
+                duration_sec=record.duration_sec,
+                estimated_reduction_percent=None,
+                estimated_savings_bytes=None,
+                status_detail=skip_detail,
             )
-            logger.debug("Aliased %s record to new path %s (duplicate detection)", duplicate.status, filename)
-            index.upsert(record)
-            return _record_to_result(file_path, record, index)
-        # Duplicate is only SCANNED - nothing decided to mirror; fall through and create a
-        # fresh SCANNED record for this path below.
 
-    # New file or previously SCANNED - create new SCANNED record
-    record = _create_scanned_record(file_path, path_hash, file_size, file_mtime, video_info, anonymize)
+        # Estimate reduction based on similar files
+        est_reduction, similar_count = _estimate_reduction(record, index)
+        record.estimated_reduction_percent = est_reduction
+        record.estimated_from_similar = similar_count
 
-    # Check for skip conditions
-    skip_status, skip_detail = _check_skip_conditions(record, video_info)
-    if skip_status:
-        record.skip_reason = skip_detail
+        # Save to index
         index.upsert(record)
+
+        # Calculate estimated savings (accounting for audio which is copied unchanged)
+        est_savings = None
+        if est_reduction and file_size:
+            # Estimate audio size - not reduced, copied unchanged (meta hoisted above)
+            audio_size = 0
+            if meta.duration_sec and meta.total_audio_bitrate_kbps:
+                audio_size = int(meta.duration_sec * meta.total_audio_bitrate_kbps * 1000 / 8)
+
+            # Apply reduction only to video portion
+            video_size = max(0, file_size - audio_size)
+            est_savings = int(video_size * est_reduction / 100)
+
         return FileAnalysisResult(
             path=file_path,
             path_hash=path_hash,
-            status=skip_status,
+            status="needs_conversion",
             file_size_bytes=file_size,
             video_codec=record.video_codec,
             resolution=f"{record.width}x{record.height}" if record.width and record.height else None,
             duration_sec=record.duration_sec,
-            estimated_reduction_percent=None,
-            estimated_savings_bytes=None,
-            status_detail=skip_detail,
+            estimated_reduction_percent=est_reduction,
+            estimated_savings_bytes=est_savings,
+            status_detail=f"Est. based on {similar_count} similar files"
+            if similar_count
+            else "Est. (no similar files)",
         )
-
-    # Estimate reduction based on similar files
-    est_reduction, similar_count = _estimate_reduction(record, index)
-    record.estimated_reduction_percent = est_reduction
-    record.estimated_from_similar = similar_count
-
-    # Save to index
-    index.upsert(record)
-
-    # Calculate estimated savings (accounting for audio which is copied unchanged)
-    est_savings = None
-    if est_reduction and file_size:
-        # Estimate audio size - not reduced, copied unchanged (meta hoisted above)
-        audio_size = 0
-        if meta.duration_sec and meta.total_audio_bitrate_kbps:
-            audio_size = int(meta.duration_sec * meta.total_audio_bitrate_kbps * 1000 / 8)
-
-        # Apply reduction only to video portion
-        video_size = max(0, file_size - audio_size)
-        est_savings = int(video_size * est_reduction / 100)
-
-    return FileAnalysisResult(
-        path=file_path,
-        path_hash=path_hash,
-        status="needs_conversion",
-        file_size_bytes=file_size,
-        video_codec=record.video_codec,
-        resolution=f"{record.width}x{record.height}" if record.width and record.height else None,
-        duration_sec=record.duration_sec,
-        estimated_reduction_percent=est_reduction,
-        estimated_savings_bytes=est_savings,
-        status_detail=f"Est. based on {similar_count} similar files" if similar_count else "Est. (no similar files)",
-    )
 
 
 def _get_output_path(input_path: str, root_path: Path, output_path: Path) -> Path:

--- a/src/history_index.py
+++ b/src/history_index.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import threading
+import time
 
 from src.config import DURATION_TOLERANCE_SEC, HISTORY_FILE, MAX_CRF_VALUE, MAX_VMAF_VALUE, RESOLUTION_TOLERANCE_PERCENT
 from src.logging_setup import get_script_directory
@@ -185,6 +186,7 @@ class HistoryIndex:
         self._lock = threading.RLock()
         self._loaded = False
         self._dirty = False
+        self._last_save_time = float("-inf")  # monotonic timestamp of the last disk write
         self._converted_cache: list[FileRecord] | None = None
         self._percentiles_cache: dict[OperationType | None, dict] | None = None
 
@@ -546,6 +548,26 @@ class HistoryIndex:
             self._save_to_disk()
             self._dirty = False
 
+    def save_if_stale(self, min_interval_sec: float) -> None:
+        """Persist changes only if the last disk write is older than min_interval_sec.
+
+        Debounces the per-file saves in the conversion worker: rewriting the whole
+        multi-MB history JSON after every processed file makes batch cost grow
+        quadratically with history size (issue #22). Callers must still call save()
+        at hard checkpoints (queue-item completion, stop, worker exit) so a crash
+        loses at most min_interval_sec of records, never a completed item.
+
+        Args:
+            min_interval_sec: Minimum seconds between disk writes.
+        """
+        with self._lock:
+            if not self._dirty:
+                return
+            if time.monotonic() - self._last_save_time < min_interval_sec:
+                return
+            self._save_to_disk()
+            self._dirty = False
+
     def _ensure_loaded(self) -> None:
         """Load from disk if not already loaded."""
         if not self._loaded:
@@ -636,6 +658,7 @@ class HistoryIndex:
 
             # Atomic rename
             os.replace(temp_path, history_path)
+            self._last_save_time = time.monotonic()
             logger.debug(f"Saved {len(self._records)} records to {history_path}")
 
         except OSError:

--- a/src/history_index.py
+++ b/src/history_index.py
@@ -188,6 +188,21 @@ class HistoryIndex:
         self._converted_cache: list[FileRecord] | None = None
         self._percentiles_cache: dict[OperationType | None, dict] | None = None
 
+    @contextlib.contextmanager
+    def transaction(self):
+        """Hold the index lock across a multi-step read-decide-write sequence.
+
+        Individual methods are already thread-safe, but a lookup -> find_better_duplicate
+        -> upsert sequence spanning several calls is not atomic on its own: two parallel
+        scan workers processing two copies of the same physical file can both pass
+        find_better_duplicate before either upserts (issue #22). Wrapping the sequence
+        in ``with index.transaction():`` serializes it. The lock is reentrant, so index
+        methods called inside the block keep working.
+        """
+        with self._lock:
+            self._ensure_loaded()
+            yield
+
     def get(self, path_hash: str) -> FileRecord | None:
         """Get a record by its path hash.
 

--- a/tests/test_history_index.py
+++ b/tests/test_history_index.py
@@ -1,0 +1,234 @@
+# tests/test_history_index.py
+"""Tests for src/history_index.py: persistence, aliases, and locking."""
+
+import threading
+import time
+
+import pytest
+from src.folder_analysis import _analyze_file
+from src.history_index import HistoryIndex, compute_filename_hash, compute_path_hash, create_alias_record
+from src.models import FileRecord, FileStatus, VideoMetadata
+
+DURATION = 120.0
+SIZE_BYTES = 11  # len(b"video-bytes")
+
+
+@pytest.fixture
+def history_file(tmp_path, monkeypatch):
+    """Point the history file at a per-test temp path (never the real one)."""
+    path = tmp_path / "history.json"
+    monkeypatch.setattr("src.history_index.get_history_path", lambda: str(path))
+    return path
+
+
+@pytest.fixture
+def index(history_file):
+    """A fresh, isolated HistoryIndex instance (bypasses the singleton)."""
+    return HistoryIndex()
+
+
+def make_record(file_path: str, *, status: FileStatus = FileStatus.SCANNED, **overrides) -> FileRecord:
+    fields = {
+        "path_hash": compute_path_hash(file_path),
+        "original_path": file_path,
+        "status": status,
+        "filename_hash": compute_filename_hash(file_path),
+        "file_size_bytes": SIZE_BYTES,
+        "file_mtime": 1000.0,
+        "duration_sec": DURATION,
+        "video_codec": "h264",
+        "width": 1920,
+        "height": 1080,
+        "last_updated": "2026-01-01 00:00:00",
+    }
+    fields.update(overrides)
+    return FileRecord(**fields)
+
+
+def make_ffprobe_info() -> dict:
+    """Fake ffprobe output accepted by extract_video_metadata()."""
+    return {
+        "streams": [
+            {"codec_type": "video", "codec_name": "h264", "width": 1920, "height": 1080, "r_frame_rate": "24/1"}
+        ],
+        "format": {"duration": str(DURATION), "bit_rate": "5000000"},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Load/save round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_save_load_roundtrip(history_file, index):
+    record = make_record(
+        "/videos/movie.mkv",
+        status=FileStatus.ANALYZED,
+        best_crf=28,
+        best_vmaf_achieved=95.5,
+        predicted_size_reduction=40.0,
+    )
+    index.upsert(record)
+    index.save()
+
+    assert history_file.exists()
+
+    reloaded = HistoryIndex()
+    loaded = reloaded.get(record.path_hash)
+    assert loaded == record
+    # Size index is rebuilt on load (duplicate detection depends on it)
+    assert reloaded.find_by_size(SIZE_BYTES) == [record]
+
+
+def test_save_is_noop_when_not_dirty(history_file, index):
+    index.get("0" * 16)  # Force load without mutating
+    index.save()
+    assert not history_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# create_alias_record
+# ---------------------------------------------------------------------------
+
+
+def test_create_alias_record_mirrors_verdict_and_rekeys_identity(index):
+    source = make_record(
+        "/videos/movie.mkv",
+        status=FileStatus.ANALYZED,
+        best_crf=28,
+        best_vmaf_achieved=95.5,
+        predicted_size_reduction=40.0,
+        estimated_reduction_percent=33.0,
+        estimated_from_similar=4,
+    )
+    alias_path = "/copies/movie.mkv"
+    alias = create_alias_record(
+        source,
+        prior_first_seen="2025-06-01 12:00:00",
+        file_path=alias_path,
+        path_hash=compute_path_hash(alias_path),
+        file_size=SIZE_BYTES,
+        file_mtime=2000.0,
+        meta=VideoMetadata(duration_sec=DURATION, video_codec="h264", width=1920, height=1080),
+        anonymize=False,
+    )
+
+    # Identity is this path's
+    assert alias.path_hash == compute_path_hash(alias_path)
+    assert alias.original_path == alias_path
+    assert alias.file_mtime == 2000.0
+    assert alias.first_seen == "2025-06-01 12:00:00"
+    # Verdict mirrors the source
+    assert alias.duplicate_of == source.path_hash
+    assert alias.status == FileStatus.ANALYZED
+    assert alias.best_crf == 28
+    # Estimates are cleared on a decided record
+    assert alias.estimated_reduction_percent is None
+    assert alias.estimated_from_similar is None
+
+    # Aliases never enter the size index (must not become duplicate candidates)
+    index.upsert(source)
+    index.upsert(alias)
+    assert index.find_by_size(SIZE_BYTES) == [source]
+
+
+# ---------------------------------------------------------------------------
+# delete
+# ---------------------------------------------------------------------------
+
+
+def test_delete_removes_record_and_size_index_entry(index):
+    record = make_record("/videos/movie.mkv")
+    index.upsert(record)
+
+    assert index.delete(record.path_hash) is True
+    assert index.get(record.path_hash) is None
+    assert index.find_by_size(SIZE_BYTES) == []
+    # Second delete is a no-op
+    assert index.delete(record.path_hash) is False
+
+
+# ---------------------------------------------------------------------------
+# Concurrency: duplicate resolution must be atomic (issue #22)
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_scan_of_duplicates_yields_one_canonical(tmp_path, index, monkeypatch):
+    """Two parallel workers resolving duplicates must serialize on the index.
+
+    Setup: a decided ANALYZED record (source) plus a stale SCANNED record at
+    path1 sharing its size/duration. path1 (same filename as the source) and
+    path2 (renamed copy) are scanned concurrently.
+
+    Serialized via index.transaction(): worker A aliases path1 to the source,
+    which retires the stale SCANNED record from the size index; worker B then
+    sees the source as the unique size+duration match (ADR-001 step 3) and
+    aliases too - one canonical, two aliases.
+
+    Unfixed race: B runs find_better_duplicate before A upserts, still sees the
+    stale SCANNED record, the step-3 uniqueness check fails, and B writes a
+    second canonical record for the same physical file.
+    """
+    root = tmp_path / "videos"
+    (root / "dir1").mkdir(parents=True)
+    (root / "dir2").mkdir(parents=True)
+    out = tmp_path / "out"  # deliberately nonexistent: no output-exists short-circuit
+
+    path1 = str(root / "dir1" / "movie.mkv")
+    path2 = str(root / "dir2" / "renamed.mkv")
+    (root / "dir1" / "movie.mkv").write_bytes(b"video-bytes")
+    (root / "dir2" / "renamed.mkv").write_bytes(b"video-bytes")
+
+    # Decided source record under a third path (file itself no longer around)
+    source = make_record(
+        "/videos/original/movie.mkv",
+        status=FileStatus.ANALYZED,
+        best_crf=28,
+        best_vmaf_achieved=95.5,
+        predicted_size_reduction=40.0,
+    )
+    index.upsert(source)
+    # Stale SCANNED record for path1 (content unchanged, mtime stamp outdated)
+    index.upsert(make_record(path1, file_mtime=1.0))
+
+    monkeypatch.setattr("src.folder_analysis.get_video_info", lambda _path: make_ffprobe_info())
+
+    # Widen the race window: pause after find_better_duplicate computes its
+    # result, before the caller upserts. With the fix the pause happens inside
+    # the transaction, so the second worker cannot interleave.
+    in_find = threading.Event()
+    original_find = HistoryIndex.find_better_duplicate
+
+    def slow_find(self, *args, **kwargs):
+        result = original_find(self, *args, **kwargs)
+        in_find.set()
+        time.sleep(0.3)
+        return result
+
+    monkeypatch.setattr(HistoryIndex, "find_better_duplicate", slow_find)
+
+    errors: list[Exception] = []
+
+    def analyze(path: str) -> None:
+        try:
+            _analyze_file(path, root, out, index, anonymize=False)
+        except Exception as e:  # pragma: no cover - failure reporting only
+            errors.append(e)
+
+    worker_a = threading.Thread(target=analyze, args=(path1,))
+    worker_b = threading.Thread(target=analyze, args=(path2,))
+    worker_a.start()
+    assert in_find.wait(timeout=5.0), "worker A never reached find_better_duplicate"
+    worker_b.start()
+    worker_a.join(timeout=10.0)
+    worker_b.join(timeout=10.0)
+
+    assert not errors
+
+    record1 = index.get(compute_path_hash(path1))
+    record2 = index.get(compute_path_hash(path2))
+    assert record1 is not None and record1.duplicate_of == source.path_hash
+    assert record2 is not None and record2.duplicate_of == source.path_hash
+
+    canonical = [r for r in index.get_all_records() if r.duplicate_of is None]
+    assert canonical == [source]

--- a/tests/test_history_index.py
+++ b/tests/test_history_index.py
@@ -1,6 +1,7 @@
 # tests/test_history_index.py
 """Tests for src/history_index.py: persistence, aliases, and locking."""
 
+import json
 import threading
 import time
 
@@ -232,3 +233,56 @@ def test_concurrent_scan_of_duplicates_yields_one_canonical(tmp_path, index, mon
 
     canonical = [r for r in index.get_all_records() if r.duplicate_of is None]
     assert canonical == [source]
+
+
+# ---------------------------------------------------------------------------
+# save_if_stale debouncing (issue #22)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    """Controllable replacement for time.monotonic inside history_index."""
+    now = [1000.0]
+    monkeypatch.setattr("src.history_index.time.monotonic", lambda: now[0])
+    return now
+
+
+def records_on_disk(history_file) -> int:
+    return len(json.loads(history_file.read_text(encoding="utf-8")))
+
+
+def test_save_if_stale_suppresses_saves_within_interval(index, clock, history_file):
+    index.upsert(make_record("/videos/a.mkv"))
+    index.save_if_stale(30)  # No prior save -> writes immediately
+    assert records_on_disk(history_file) == 1
+
+    index.upsert(make_record("/videos/b.mkv"))
+    clock[0] += 10
+    index.save_if_stale(30)  # Dirty, but only 10s since last write -> suppressed
+    assert records_on_disk(history_file) == 1
+
+    clock[0] += 25  # 35s since last write
+    index.save_if_stale(30)  # Stale -> writes
+    assert records_on_disk(history_file) == 2
+
+
+def test_forced_flush_saves_regardless_of_interval(index, clock, history_file):
+    index.upsert(make_record("/videos/a.mkv"))
+    index.save_if_stale(30)
+    assert records_on_disk(history_file) == 1
+
+    index.upsert(make_record("/videos/b.mkv"))
+    clock[0] += 1
+    index.save()  # Mandatory flush ignores the debounce interval
+    assert records_on_disk(history_file) == 2
+
+
+def test_save_if_stale_respects_dirty_flag(index, clock, history_file):
+    index.upsert(make_record("/videos/a.mkv"))
+    index.save()
+    history_file.unlink()
+
+    clock[0] += 100  # Interval elapsed, but nothing changed since the last save
+    index.save_if_stale(30)
+    assert not history_file.exists()


### PR DESCRIPTION
Two mitigations from #22, plus the first `HistoryIndex` test coverage from #23. The on-disk history format is untouched.

Duplicate resolution during a parallel scan was a read-then-write race: `_analyze_file` called `get`, `find_better_duplicate`, and `upsert` as three separate lock acquisitions across 4-8 ThreadPoolExecutor workers, so two workers scanning copies of the same file could both pass the duplicate check and write two canonical records. A new `HistoryIndex.transaction()` context manager (over the existing reentrant lock) now wraps everything after the ffprobe; the probe deliberately stays outside the lock so slow probes don't serialize the pool, and the cached-record read is repeated inside the transaction since the pre-probe read can be stale. A new concurrency test reproduces the race and fails on the unfixed code.

The worker previously rewrote the entire history file after every processed file. `_save_file_record` and the alias write now go through `save_if_stale(HISTORY_SAVE_INTERVAL_SEC)` (30 seconds, new constant in `config.py`), with unconditional flushes at queue-item completion, stop handling, and a new try/finally around the processing loop covering crashes and normal exit. A crash loses at most 30 seconds of records, never a completed item. `save()` itself is unchanged and remains the unconditional flush; the analysis scanner's existing batching is untouched.

Eight new tests in `tests/test_history_index.py` (concurrency, save/load round-trip, alias creation, delete, and debounce behavior with a fake clock), isolated from the real `conversion_history.json` via a monkeypatched history path.

Review note: the worker diff looks larger than it is because the new try/finally re-indents the processing loop; `git diff -w` shows the real changes.
