### PR TITLE
fix(ab-av1): Support fractional CRF from 0.11 quarter-step search

### DIFF
--- a/docs/AB_AV1_PARSING.md
+++ b/docs/AB_AV1_PARSING.md
@@ -14,14 +14,17 @@ The parser (`src/ab_av1/parser.py`) handles both phases with different regex pat
 ## Phase 1: CRF Search
 
 During CRF search, ab-av1 samples the video at various CRF values to find one meeting the VMAF target.
+Since ab-av1 0.11.0, libsvtav1 is searched in quarter-CRF steps (default `--crf-increment` 0.25) over a
+default range of [5, 70], so CRF values may be fractional (e.g. `23.25`). Requires SVT-AV1 ≥ 4.0
+(older versions silently truncate fractional CRF).
 
 ### Output Format
 
 ```
 crf 30 VMAF 96.5
 crf 32 VMAF 94.2
-crf 31 VMAF 95.1
-Best CRF: 31
+crf 31.25 VMAF 95.1
+Best CRF: 31.25
 predicted video stream size 450MB (65%)
 ```
 
@@ -29,8 +32,8 @@ predicted video stream size 450MB (65%)
 
 | Pattern | Purpose | Example Match |
 |---------|---------|---------------|
-| `crf\s+(\d+)\s+VMAF\s+(\d+\.?\d*)` | Extract CRF/VMAF pairs | `crf 31 VMAF 95.1` |
-| `Best\s+CRF:\s+(\d+)` | Final CRF selection | `Best CRF: 31` |
+| `crf\s+(\d+\.?\d*)\s+VMAF\s+(\d+\.?\d*)` | Extract CRF/VMAF pairs | `crf 31.25 VMAF 95.1` |
+| `Best\s+CRF:\s+(\d+\.?\d*)` | Final CRF selection | `Best CRF: 31.25` |
 | `predicted video stream size.*?\((\d+\.?\d*)\s*%\)` | Size prediction | `(65%)` |
 
 ### Progress Heuristic
@@ -123,7 +126,7 @@ The parser maintains and updates a stats dictionary:
 | `phase` | str | `"crf-search"` or `"encoding"` |
 | `progress_quality` | float | 0-100, CRF search progress |
 | `progress_encoding` | float | 0-100, encoding progress |
-| `crf` | int | Current/best CRF value |
+| `crf` | float | Current/best CRF value (fractional since ab-av1 0.11) |
 | `vmaf` | float | Current/best VMAF score |
 | `size_reduction` | float | Predicted size reduction % |
 | `eta_text` | str | ETA string from ab-av1 |

--- a/docs/HISTORY_FORMAT.md
+++ b/docs/HISTORY_FORMAT.md
@@ -98,7 +98,7 @@ Populated after running CRF search (either standalone ANALYZE or as part of CONV
 |-------|------|-------------|
 | `vmaf_target_when_analyzed` | int\|null | VMAF target achieved |
 | `preset_when_analyzed` | int\|null | SVT-AV1 preset used |
-| `best_crf` | int\|null | Optimal CRF value found |
+| `best_crf` | float\|null | Optimal CRF value found (fractional since ab-av1 0.11) |
 | `best_vmaf_achieved` | float\|null | VMAF score at best CRF |
 | `predicted_output_size` | int\|null | Predicted output bytes |
 | `predicted_size_reduction` | float\|null | Accurate reduction % |
@@ -126,7 +126,7 @@ Populated after successful encoding.
 | `output_size_bytes` | int\|null | Actual output file size |
 | `reduction_percent` | float\|null | Actual size reduction |
 | `encoding_time_sec` | float\|null | Encoding phase duration |
-| `final_crf` | int\|null | CRF used for encoding |
+| `final_crf` | float\|null | CRF used for encoding (fractional since ab-av1 0.11) |
 | `final_vmaf` | float\|null | Actual VMAF achieved |
 | `vmaf_target_used` | int\|null | Target (may differ from requested due to fallback) |
 | `output_audio_codec` | string\|null | Audio codec in output |

--- a/src/ab_av1/parser.py
+++ b/src/ab_av1/parser.py
@@ -13,6 +13,7 @@ from typing import Any
 from src.config import SIZE_REDUCTION_CHANGE_THRESHOLD, VMAF_CHANGE_THRESHOLD
 from src.models import ProgressEvent
 from src.privacy import anonymize_filename
+from src.utils import format_crf
 
 logger = logging.getLogger(__name__)
 
@@ -48,8 +49,8 @@ class AbAv1Parser:
         self._re_main_encoding = re.compile(
             r"command::encode\]\s*(\d+)%,\s*(\d+)\s*fps,\s*eta\s+([\w\s]+)(?:$|\)|\])", re.IGNORECASE
         )
-        self._re_crf_vmaf = re.compile(r"crf\s+(\d+)\s+VMAF\s+(\d+\.?\d*)", re.IGNORECASE)
-        self._re_best_crf = re.compile(r"Best\s+CRF:\s+(\d+)", re.IGNORECASE)
+        self._re_crf_vmaf = re.compile(r"crf\s+(\d+\.?\d*)\s+VMAF\s+(\d+\.?\d*)", re.IGNORECASE)
+        self._re_best_crf = re.compile(r"Best\s+CRF:\s+(\d+\.?\d*)", re.IGNORECASE)
         self._re_size_reduction_percent = re.compile(
             r"predicted video stream size.*?\((\d+\.?\d*)\s*%\)", re.IGNORECASE
         )
@@ -69,7 +70,7 @@ class AbAv1Parser:
 
         # Final output parsing patterns
         self._re_final_vmaf = re.compile(r"VMAF\s+(\d+\.\d+)", re.IGNORECASE)
-        self._re_final_crf = re.compile(r"Best\s+CRF:\s+(\d+)", re.IGNORECASE)
+        self._re_final_crf = re.compile(r"Best\s+CRF:\s+(\d+\.?\d*)", re.IGNORECASE)
 
     def _build_encoding_callback_data(
         self, stats: dict[str, Any], progress_encoding: float, message: str, eta_text: str | None = None
@@ -162,11 +163,11 @@ class AbAv1Parser:
                 if crf_vmaf_match:
                     processed_line = True
                     try:
-                        crf_val = int(crf_vmaf_match.group(1))
+                        crf_val = float(crf_vmaf_match.group(1))
                         vmaf_val = float(crf_vmaf_match.group(2))
                         stats["crf"] = crf_val
                         stats["vmaf"] = vmaf_val
-                        logger.info(f"CRF search update: CRF={stats['crf']}, VMAF={stats['vmaf']:.2f}")
+                        logger.info(f"CRF search update: CRF={format_crf(stats['crf'])}, VMAF={stats['vmaf']:.2f}")
                         new_quality_progress = min(90.0, stats.get("progress_quality", 0) + 10.0)
                     except (ValueError, IndexError) as e:
                         logger.warning(f"Error parsing CRF/VMAF values from line '{line[:80]}...': {e}")
@@ -175,9 +176,9 @@ class AbAv1Parser:
                 if best_crf_match:
                     processed_line = True
                     try:
-                        crf_val = int(best_crf_match.group(1))
+                        crf_val = float(best_crf_match.group(1))
                         stats["crf"] = crf_val
-                        logger.info(f"Best CRF determined: {stats['crf']}")
+                        logger.info(f"Best CRF determined: {format_crf(stats['crf'])}")
                         new_quality_progress = 95.0
                     except (ValueError, IndexError) as e:
                         logger.warning(f"Error parsing Best CRF value from line '{line[:80]}...': {e}")
@@ -215,11 +216,10 @@ class AbAv1Parser:
                                 vmaf_part = f"{float(current_vmaf):.1f}"
                             except (ValueError, TypeError):
                                 vmaf_part = str(current_vmaf)
-
                         callback_info = ProgressEvent(
                             progress_quality=stats["progress_quality"],
                             progress_encoding=0,
-                            message=f"Detecting Quality (CRF:{stats.get('crf', '?')}, VMAF:{vmaf_part})",
+                            message=f"Detecting Quality (CRF:{format_crf(stats.get('crf'))}, VMAF:{vmaf_part})",
                             phase=current_phase,
                             vmaf=stats.get("vmaf"),
                             crf=stats.get("crf"),
@@ -426,9 +426,11 @@ class AbAv1Parser:
         try:
             crf_matches = self._re_final_crf.findall(output_text)
             if crf_matches:
-                final_crf = int(crf_matches[-1])
+                final_crf = float(crf_matches[-1])
                 if stats.get("crf") != final_crf:
-                    logger.info(f"[Final Parse] CRF verified/updated: {final_crf} (from {stats.get('crf')})")
+                    logger.info(
+                        f"[Final Parse] CRF verified/updated: {format_crf(final_crf)} (from {stats.get('crf')})"
+                    )
                     stats["crf"] = final_crf
             elif stats.get("crf") is None:
                 logger.warning("[Final Parse] Could not find Best CRF in main pipe output.")

--- a/src/ab_av1/parser.py
+++ b/src/ab_av1/parser.py
@@ -135,7 +135,7 @@ class AbAv1Parser:
 
                 # Log extra information about this transition
                 logger.info(
-                    f"Starting encoding phase with CRF: {stats.get('crf', '?')}, "
+                    f"Starting encoding phase with CRF: {format_crf(stats.get('crf'))}, "
                     f"VMAF Target: {stats.get('vmaf_target_used', '?')}"
                 )
                 logger.info(f"Duration in seconds: {stats.get('total_duration_seconds', '?')}")
@@ -386,7 +386,7 @@ class AbAv1Parser:
                 logger.debug(
                     f"Post-Parse Stats: Phase={stats.get('phase')}, "
                     f"Qual={stats.get('progress_quality', 0):.1f}%, VMAF={stats.get('vmaf')}, "
-                    f"CRF={stats.get('crf')}, ETA={stats.get('eta_text')}, "
+                    f"CRF={format_crf(stats.get('crf'))}, ETA={stats.get('eta_text')}, "
                     f"SizeReduc={stats.get('size_reduction')}"
                 )
 

--- a/src/ab_av1/wrapper.py
+++ b/src/ab_av1/wrapper.py
@@ -608,7 +608,7 @@ class AbAv1Wrapper:
 
         # --- Logging Final Stats ---
         if stats.get("crf") is not None:
-            logger.info(f"Final CRF: {stats['crf']}")
+            logger.info(f"Final CRF: {format_crf(stats['crf'])}")
         if stats.get("vmaf") is not None:
             logger.info(f"Final VMAF: {stats['vmaf']:.2f}")
         if stats.get("size_reduction") is not None:

--- a/src/ab_av1/wrapper.py
+++ b/src/ab_av1/wrapper.py
@@ -20,7 +20,7 @@ from typing import Any
 from src.config import DEFAULT_ENCODING_PRESET, DEFAULT_VMAF_TARGET, MIN_VMAF_FALLBACK_TARGET, VMAF_FALLBACK_STEP
 from src.platform_utils import get_windows_subprocess_startupinfo
 from src.privacy import anonymize_filename
-from src.utils import format_file_size, get_video_info
+from src.utils import format_crf, format_file_size, get_video_info
 from src.vendor_manager import AB_AV1_EXE, AB_AV1_EXE_NAME, FFMPEG_DIR, get_ab_av1_path
 from src.video_metadata import extract_video_metadata
 
@@ -690,7 +690,7 @@ class AbAv1Wrapper:
 
         Returns:
             Dictionary containing:
-                - best_crf: int - Optimal CRF value found
+                - best_crf: float - Optimal CRF value found (fractional since ab-av1 0.11)
                 - best_vmaf: float - VMAF score achieved at best CRF
                 - predicted_size_reduction: float - Predicted size reduction percentage
                 - predicted_output_size: int | None - Estimated output file size in bytes
@@ -861,7 +861,7 @@ class AbAv1Wrapper:
                             vmaf_suffix = f" (target: {current_vmaf_target})"
                         else:
                             vmaf_suffix = ""
-                        message = f"CRF:{stats.get('crf', '?')}, VMAF:{stats.get('vmaf', '?')}{vmaf_suffix}"
+                        message = f"CRF:{format_crf(stats.get('crf'))}, VMAF:{stats.get('vmaf', '?')}{vmaf_suffix}"
                         progress_callback(stats["progress_quality"], message)
 
                 # Close stdout
@@ -936,7 +936,7 @@ class AbAv1Wrapper:
                 }
 
                 logger.info(
-                    f"CRF search complete: CRF={result['best_crf']}, "
+                    f"CRF search complete: CRF={format_crf(result['best_crf'])}, "
                     f"VMAF={result['best_vmaf']:.2f}, "
                     f"Reduction={result.get('predicted_size_reduction', 'N/A')}%, "
                     f"Target={current_vmaf_target}"
@@ -980,7 +980,7 @@ class AbAv1Wrapper:
         self,
         input_path: str,
         output_path: str,
-        crf: int,
+        crf: float,
         preset: int | None = None,
         file_info_callback: Callable[..., Any] | None = None,
         pid_callback: Callable[..., Any] | None = None,
@@ -1083,7 +1083,7 @@ class AbAv1Wrapper:
             "--preset",
             str(preset),
             "--crf",
-            str(crf),
+            format_crf(crf),
         ]
 
         # Add hardware decoder if specified
@@ -1108,7 +1108,7 @@ class AbAv1Wrapper:
             "--preset",
             str(preset),
             "--crf",
-            str(crf),
+            format_crf(crf),
         ]
         if log_interval:
             cmd_for_log.extend(["--log-interval", log_interval])
@@ -1141,7 +1141,7 @@ class AbAv1Wrapper:
         # --- Starting Callback ---
         if self.file_info_callback:
             callback_info = {
-                "message": f"Encoding with cached CRF {crf}",
+                "message": f"Encoding with cached CRF {format_crf(crf)}",
                 "crf": crf,
                 "original_size": stats.get("original_size"),
                 "used_cached_crf": True,
@@ -1284,7 +1284,7 @@ class AbAv1Wrapper:
             raise OutputFileError(error_msg, command=cmd_str_log, error_type="missing_output_on_success")
 
         # --- Success ---
-        logger.info(f"Encode completed successfully for {anonymized_input_path} (CRF {crf})")
+        logger.info(f"Encode completed successfully for {anonymized_input_path} (CRF {format_crf(crf)})")
         stats = self.parser.parse_final_output(full_output_text, stats)
         stats["crf"] = crf  # Ensure CRF is set
 
@@ -1305,7 +1305,7 @@ class AbAv1Wrapper:
         # --- Completion Callback ---
         if self.file_info_callback:
             final_stats_for_callback = {
-                "message": f"Complete (CRF {crf}, cached)",
+                "message": f"Complete (CRF {format_crf(crf)}, cached)",
                 "crf": crf,
                 "size_reduction": stats.get("size_reduction"),
                 "output_path": output_path,

--- a/src/config.py
+++ b/src/config.py
@@ -60,7 +60,7 @@ VMAF_CHANGE_THRESHOLD = 0.01  # VMAF score difference to trigger update
 MIN_OUTPUT_FILE_SIZE = 1024  # Minimum bytes for valid output file (1 KB)
 
 # --- Record Validation ---
-MAX_CRF_VALUE = 63  # Maximum valid CRF value for AV1/HEVC/H264
+MAX_CRF_VALUE = 70  # Maximum valid CRF value (ab-av1 0.11+ searches svt-av1 up to CRF 70)
 MAX_VMAF_VALUE = 100  # Maximum valid VMAF score
 
 # --- History File ---

--- a/src/config.py
+++ b/src/config.py
@@ -61,6 +61,7 @@ MIN_OUTPUT_FILE_SIZE = 1024  # Minimum bytes for valid output file (1 KB)
 
 # --- Record Validation ---
 MAX_CRF_VALUE = 70  # Maximum valid CRF value (ab-av1 0.11+ searches svt-av1 up to CRF 70)
+MIN_SVT_AV1_MAJOR_FOR_FRACTIONAL_CRF = 4  # Older SVT-AV1 silently truncates fractional CRF values
 MAX_VMAF_VALUE = 100  # Maximum valid VMAF score
 
 # --- History File ---

--- a/src/conversion_engine/worker.py
+++ b/src/conversion_engine/worker.py
@@ -36,7 +36,7 @@ from src.models import (
     QueueItemStatus,
 )
 from src.privacy import anonymize_filename
-from src.utils import get_video_info, update_ui_safely
+from src.utils import format_crf, get_video_info, update_ui_safely
 from src.video_conversion import calculate_output_path, process_video
 from src.video_metadata import extract_video_metadata
 
@@ -85,7 +85,7 @@ def _create_file_record(
     output_size: int | None = None,
     crf_search_time_sec: float | None = None,
     encoding_time_sec: float | None = None,
-    final_crf: int | None = None,
+    final_crf: float | None = None,
     final_vmaf: float | None = None,
     vmaf_target: int | None = None,
     output_acodec: str | None = None,
@@ -334,10 +334,7 @@ def sequential_conversion_worker(
     # Count pending items and total files across all pending queue items
     pending_items = [item for item in config.queue_items if item.status == QueueItemStatus.PENDING]
     items_total = len(pending_items)
-    total_files_in_queue = sum(
-        len(item.files) if item.is_folder else 1
-        for item in pending_items
-    )
+    total_files_in_queue = sum(len(item.files) if item.is_folder else 1 for item in pending_items)
     items_completed = 0
 
     logger.info(f"Total queue items to process: {items_total} ({total_files_in_queue} files)")
@@ -424,6 +421,7 @@ def sequential_conversion_worker(
                     stopped_file_count = len(remaining_files)
                     for remaining_file in remaining_files:
                         remaining_file.status = QueueItemStatus.STOPPED
+
                     def increment_stopped_count(n=stopped_file_count):
                         gui.session.stopped_count += n
 
@@ -555,8 +553,7 @@ def sequential_conversion_worker(
                     reason_lower = reason.lower() if reason else ""
                     tree_status = "done" if "already converted" in reason_lower else "skip"
                     update_ui_safely(
-                        gui.root,
-                        lambda fp=file_path, s=tree_status: gui.update_analysis_tree_for_completed_file(fp, s)
+                        gui.root, lambda fp=file_path, s=tree_status: gui.update_analysis_tree_for_completed_file(fp, s)
                     )
                     continue
 
@@ -630,7 +627,7 @@ def sequential_conversion_worker(
                         )
                         update_ui_safely(
                             gui.root,
-                            lambda fp=file_path, s=tree_status: gui.update_analysis_tree_for_completed_file(fp, s)
+                            lambda fp=file_path, s=tree_status: gui.update_analysis_tree_for_completed_file(fp, s),
                         )
                         continue
 
@@ -788,7 +785,9 @@ def sequential_conversion_worker(
                                 filename,
                                 "completed",
                                 {
-                                    "message": f"Analysis complete (CRF {final_crf}, VMAF {final_vmaf:.2f})",
+                                    "message": (
+                                        f"Analysis complete (CRF {format_crf(final_crf)}, VMAF {final_vmaf:.2f})"
+                                    ),
                                     "crf": final_crf,
                                     "vmaf": final_vmaf,
                                     "vmaf_target_used": final_vmaf_target,
@@ -798,13 +797,13 @@ def sequential_conversion_worker(
                             queue_item.files_succeeded += 1
                             _update_file_status(queue_item, file_index, QueueItemStatus.COMPLETED)
                             logger.info(
-                                f"Analysis complete for {anonymized_name}: CRF {final_crf}, VMAF {final_vmaf:.2f}"
+                                f"Analysis complete for {anonymized_name}: "
+                                f"CRF {format_crf(final_crf)}, VMAF {final_vmaf:.2f}"
                             )
 
                             # Update analysis tree now that history is saved
                             update_ui_safely(
-                                gui.root,
-                                lambda fp=file_path: gui.update_analysis_tree_for_completed_file(fp, "done")
+                                gui.root, lambda fp=file_path: gui.update_analysis_tree_for_completed_file(fp, "done")
                             )
 
                         except ConversionNotWorthwhileError as e:
@@ -845,8 +844,7 @@ def sequential_conversion_worker(
 
                             # Update analysis tree now that history is saved
                             update_ui_safely(
-                                gui.root,
-                                lambda fp=file_path: gui.update_analysis_tree_for_completed_file(fp, "skip")
+                                gui.root, lambda fp=file_path: gui.update_analysis_tree_for_completed_file(fp, "skip")
                             )
 
                             process_successful = False
@@ -970,8 +968,7 @@ def sequential_conversion_worker(
                             _save_file_record(record)
                             # Update analysis tree now that history is saved
                             update_ui_safely(
-                                gui.root,
-                                lambda fp=file_path: gui.update_analysis_tree_for_completed_file(fp, "done")
+                                gui.root, lambda fp=file_path: gui.update_analysis_tree_for_completed_file(fp, "done")
                             )
                         except Exception:
                             logger.exception(f"Failed to record history for {anonymized_name}")
@@ -1012,8 +1009,7 @@ def sequential_conversion_worker(
                         logger.info(f"Recorded NOT_WORTHWHILE status to history for {anonymized_name}")
                         # Update analysis tree now that history is saved
                         update_ui_safely(
-                            gui.root,
-                            lambda fp=file_path: gui.update_analysis_tree_for_completed_file(fp, "skip")
+                            gui.root, lambda fp=file_path: gui.update_analysis_tree_for_completed_file(fp, "skip")
                         )
                     except Exception:
                         logger.exception(f"Failed to record NOT_WORTHWHILE history for {anonymized_name}")

--- a/src/folder_analysis.py
+++ b/src/folder_analysis.py
@@ -26,7 +26,7 @@ from src.cache_helpers import mtimes_match
 from src.config import DEFAULT_REDUCTION_ESTIMATE_PERCENT
 from src.history_index import HistoryIndex, compute_filename_hash, compute_path_hash, create_alias_record
 from src.models import DECIDED_STATUSES, FileRecord, FileStatus, VideoMetadata
-from src.utils import get_video_info
+from src.utils import format_crf, get_video_info
 from src.video_metadata import extract_video_metadata
 
 logger = logging.getLogger(__name__)
@@ -512,7 +512,11 @@ def _record_to_result(file_path: str, record: FileRecord, index: HistoryIndex) -
     elif record.status == FileStatus.ANALYZED:
         # ANALYZED files need conversion but have accurate predictions (Layer 2 complete)
         status = "needs_conversion"
-        detail = f"CRF {record.best_crf} → VMAF {record.best_vmaf_achieved:.1f}" if record.best_crf else None
+        detail = (
+            f"CRF {format_crf(record.best_crf)} → VMAF {record.best_vmaf_achieved:.1f}"
+            if record.best_crf is not None
+            else None
+        )
     elif record.skip_reason:
         status = "skipped_other"
         detail = record.skip_reason

--- a/src/gui/analysis_controller.py
+++ b/src/gui/analysis_controller.py
@@ -22,7 +22,7 @@ from src.gui import analysis_scanner
 from src.gui.tree_formatters import clear_sort_state, format_compact_time, format_efficiency, sort_analysis_tree
 from src.history_index import get_history_index
 from src.models import FileStatus, OperationType
-from src.utils import format_file_size
+from src.utils import format_crf, format_file_size
 
 logger = logging.getLogger(__name__)
 
@@ -405,7 +405,7 @@ def get_analysis_tree_tooltip(gui, item_id: str) -> str | None:
         if record.reduction_percent is not None:
             lines[0] += f": {record.reduction_percent:.0f}% smaller"
         if record.final_crf is not None and record.final_vmaf is not None:
-            lines.append(f"CRF {record.final_crf}, VMAF {record.final_vmaf:.1f}")
+            lines.append(f"CRF {format_crf(record.final_crf)}, VMAF {record.final_vmaf:.1f}")
         return "\n".join(lines)
 
     if record.status == FileStatus.NOT_WORTHWHILE:
@@ -420,14 +420,14 @@ def get_analysis_tree_tooltip(gui, item_id: str) -> str | None:
         # Layer 2 complete (CRF search done)
         lines = ["Ready to convert (CRF search complete)"]
         if record.best_crf is not None and record.best_vmaf_achieved is not None:
-            lines.append(f"CRF {record.best_crf} → VMAF {record.best_vmaf_achieved:.1f}")
+            lines.append(f"CRF {format_crf(record.best_crf)} → VMAF {record.best_vmaf_achieved:.1f}")
         return "\n".join(lines)
 
     # FileStatus.SCANNED - check for Layer 2 data (fallback for old records)
     if record.predicted_size_reduction is not None:
         lines = ["Ready to convert (CRF search complete)"]
         if record.best_crf is not None and record.best_vmaf_achieved is not None:
-            lines.append(f"CRF {record.best_crf} → VMAF {record.best_vmaf_achieved:.1f}")
+            lines.append(f"CRF {format_crf(record.best_crf)} → VMAF {record.best_vmaf_achieved:.1f}")
         return "\n".join(lines)
 
     if record.estimated_reduction_percent is not None:

--- a/src/gui/callback_handlers.py
+++ b/src/gui/callback_handlers.py
@@ -17,7 +17,7 @@ from src.models import ErrorInfo, ProgressEvent, RetryInfo, SkippedInfo
 
 # Project Imports
 from src.privacy import anonymize_filename
-from src.utils import format_file_size, update_ui_safely
+from src.utils import format_crf, format_file_size, update_ui_safely
 
 logger = logging.getLogger(__name__)
 
@@ -164,9 +164,9 @@ def handle_completed(gui, filename, info) -> None:
     # Update CRF stats (thread-safe)
     if crf_value is not None:
         try:
-            crf_int = int(crf_value)
-            update_ui_safely(gui.root, lambda c=crf_int: gui.session.crf_values.append(c))
-            log_msg += f", CRF: {crf_int}"
+            crf_float = float(crf_value)
+            update_ui_safely(gui.root, lambda c=crf_float: gui.session.crf_values.append(c))
+            log_msg += f", CRF: {format_crf(crf_float)}"
         except (ValueError, TypeError):
             logger.warning(f"Invalid CRF value '{crf_value}' for stats in {anonymized_name}")
 

--- a/src/gui/conversion_controller.py
+++ b/src/gui/conversion_controller.py
@@ -57,7 +57,7 @@ from src.models import OutputMode, QueueConversionConfig, QueueItemStatus
 # Import from utils and other modules
 from src.platform_utils import allow_sleep_mode, get_windows_subprocess_startupinfo, prevent_sleep_mode
 from src.privacy import anonymize_filename
-from src.utils import format_file_size, format_time, update_ui_safely
+from src.utils import format_crf, format_file_size, format_time, update_ui_safely
 
 # Import the single-file processing function
 
@@ -814,7 +814,10 @@ def conversion_complete(gui, final_message="Queue complete"):
             f"{min(s.vmaf_scores):.1f}/{max(s.vmaf_scores):.1f}"
         )
     if s.crf_values:
-        logger.info(f"CRF (Avg/Min/Max): {statistics.mean(s.crf_values):.1f}/{min(s.crf_values)}/{max(s.crf_values)}")
+        logger.info(
+            f"CRF (Avg/Min/Max): {statistics.mean(s.crf_values):.1f}/"
+            f"{format_crf(min(s.crf_values))}/{format_crf(max(s.crf_values))}"
+        )
     if s.size_reductions:
         logger.info(
             f"Size Reduction (Avg/Min/Max): {statistics.mean(s.size_reductions):.1f}%/"

--- a/src/gui/gui_actions.py
+++ b/src/gui/gui_actions.py
@@ -16,8 +16,9 @@ from tkinter import filedialog, messagebox
 # Project imports - Replace 'convert_app' with 'src'
 # Import the checker function from its new location
 from src.ab_av1.checker import check_ab_av1_available
+from src.config import MIN_SVT_AV1_MAJOR_FOR_FRACTIONAL_CRF
 from src.history_index import get_history_path
-from src.utils import check_ffmpeg_availability
+from src.utils import check_ffmpeg_availability, get_svt_av1_version
 
 logger = logging.getLogger(__name__)
 
@@ -162,6 +163,22 @@ def check_ffmpeg(gui) -> bool:
             return False
     else:
         logger.info("FFmpeg with SVT-AV1 support detected.")
+        svt_version = get_svt_av1_version()
+        if svt_version is None:
+            logger.debug("Could not determine SVT-AV1 library version; skipping fractional CRF check.")
+        elif svt_version[0] < MIN_SVT_AV1_MAJOR_FOR_FRACTIONAL_CRF:
+            major, minor = svt_version
+            warning_msg = (
+                f"Your FFmpeg bundles SVT-AV1 {major}.{minor}, which silently truncates fractional "
+                f"CRF values (e.g. 23.25 becomes 23). ab-av1 searches in quarter-CRF steps, so encodes "
+                f"will not use the exact CRF found.\n\n"
+                f"Update FFmpeg from the Settings tab to get SVT-AV1 "
+                f"{MIN_SVT_AV1_MAJOR_FOR_FRACTIONAL_CRF}.0 or newer."
+            )
+            logger.warning(f"SVT-AV1 {major}.{minor} truncates fractional CRF; update FFmpeg from the Settings tab.")
+            messagebox.showwarning("SVT-AV1 Outdated", warning_msg)
+        else:
+            logger.info(f"SVT-AV1 library version: {svt_version[0]}.{svt_version[1]} (fractional CRF supported)")
 
     if version_info:
         logger.info(f"FFmpeg version: {version_info.splitlines()[0]}")

--- a/src/gui/gui_updates.py
+++ b/src/gui/gui_updates.py
@@ -20,6 +20,7 @@ from src.models import ProgressEvent
 
 # Project imports
 from src.utils import (
+    format_crf,
     format_file_size,
     format_time,
     parse_eta_text,  # Add parse_eta_text import
@@ -111,8 +112,8 @@ def update_crf_display(gui, info: ProgressEvent) -> None:
     """
     if info.crf is not None:
         try:
-            crf_val = int(info.crf)
-            settings_text = f"{crf_val}, Preset {DEFAULT_ENCODING_PRESET}"
+            crf_val = float(info.crf)
+            settings_text = f"{format_crf(crf_val)}, Preset {DEFAULT_ENCODING_PRESET}"
             update_ui_safely(gui.root, lambda s=settings_text: gui.encoding_settings_label.config(text=s))
             logger.info(f"CRF update: {settings_text}")
         except (ValueError, TypeError) as e:
@@ -358,9 +359,7 @@ def update_total_row_progress(gui) -> None:
         # Update total row (values order: format, size, est_time, operation, output, status)
         update_ui_safely(
             gui.root,
-            lambda r=remaining_str, p=progress_text: gui.queue_total_tree.item(
-                "total", values=("", "", r, "", "", p)
-            ),
+            lambda r=remaining_str, p=progress_text: gui.queue_total_tree.item("total", values=("", "", r, "", "", p)),
         )
     except Exception:
         logger.exception("Error updating total row progress")

--- a/src/gui/tabs/history_tab.py
+++ b/src/gui/tabs/history_tab.py
@@ -21,7 +21,7 @@ from src.gui.base import ToolTip, TreeviewHeaderTooltip
 from src.gui.constants import COLOR_STATUS_SUCCESS, COLOR_STATUS_WARNING, HISTORY_TREE_HEADINGS
 from src.history_index import get_history_index
 from src.models import FileRecord, FileStatus
-from src.utils import format_file_size, format_time
+from src.utils import format_crf, format_file_size, format_time
 
 logger = logging.getLogger(__name__)
 
@@ -273,7 +273,7 @@ def compute_history_display_values(record: FileRecord) -> tuple[str, ...]:
         output_size = format_file_size(record.output_size_bytes) if record.output_size_bytes else "—"
         reduction = f"{record.reduction_percent:.1f}%" if record.reduction_percent is not None else "—"
         vmaf = f"{record.final_vmaf:.1f}" if record.final_vmaf is not None else "—"
-        crf = str(record.final_crf) if record.final_crf is not None else "—"
+        crf = format_crf(record.final_crf) if record.final_crf is not None else "—"
     else:
         output_size = "—"
         reduction = "—"

--- a/src/gui/tabs/statistics_tab.py
+++ b/src/gui/tabs/statistics_tab.py
@@ -22,7 +22,7 @@ from src.gui.base import ToolTip
 from src.gui.charts import BarChart, LineGraph, PieChart
 from src.history_index import get_history_index
 from src.models import FileRecord
-from src.utils import format_file_size
+from src.utils import format_crf, format_file_size
 
 logger = logging.getLogger(__name__)
 
@@ -152,9 +152,7 @@ def _create_summary_panel(gui: "VideoConverterGUI", parent: ttk.Frame, row: int)
     throughput_label = ttk.Label(throughput_row, text="Avg Throughput:")
     throughput_label.pack(side="left")
     ToolTip(
-        throughput_label,
-        "Encoding speed in GB of source video per hour.\n"
-        "Depends on hardware and video complexity.",
+        throughput_label, "Encoding speed in GB of source video per hour.\nDepends on hardware and video complexity."
     )
     gui.throughput_stats_label = ttk.Label(throughput_row, text="-")
     gui.throughput_stats_label.pack(side="left", padx=(5, 0))
@@ -392,7 +390,7 @@ def _update_summary_labels(gui: "VideoConverterGUI", summary: dict[str, Any]) ->
             min_crf = min(crf_values)
             max_crf = max(crf_values)
             gui.crf_stats_label.config(text=f"{avg_crf:.1f}")
-            gui.crf_range_label.config(text=f"(min: {min_crf}, max: {max_crf})")
+            gui.crf_range_label.config(text=f"(min: {format_crf(min_crf)}, max: {format_crf(max_crf)})")
         except statistics.StatisticsError:
             gui.crf_stats_label.config(text="-")
             gui.crf_range_label.config(text="")

--- a/src/gui/tabs/statistics_tab.py
+++ b/src/gui/tabs/statistics_tab.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from src.gui.main_window import VideoConverterGUI
 
+from src.config import MAX_CRF_VALUE
 from src.gui.base import ToolTip
 from src.gui.charts import BarChart, LineGraph, PieChart
 from src.history_index import get_history_index
@@ -120,7 +121,7 @@ def _create_summary_panel(gui: "VideoConverterGUI", parent: ttk.Frame, row: int)
     crf_row.grid(row=2, column=0, sticky="w", pady=3)
     crf_label = ttk.Label(crf_row, text="Avg CRF Value:")
     crf_label.pack(side="left")
-    ToolTip(crf_label, "Average compression level (0-63).\nLower = higher quality encoding.")
+    ToolTip(crf_label, f"Average compression level (0-{MAX_CRF_VALUE}).\nLower = higher quality encoding.")
     gui.crf_stats_label = ttk.Label(crf_row, text="-")
     gui.crf_stats_label.pack(side="left", padx=(5, 5))
     gui.crf_range_label = ttk.Label(crf_row, text="", foreground="#666")

--- a/src/models.py
+++ b/src/models.py
@@ -365,7 +365,7 @@ class FileRecord:
     # === VMAF Analysis (Layer 2 - CRF search results) ===
     vmaf_target_when_analyzed: int | None = None  # VMAF target achieved (may be lower than requested due to fallback)
     preset_when_analyzed: int | None = None  # Encoding preset used during analysis
-    best_crf: int | None = None  # CRF that gave best VMAF (from crf-search)
+    best_crf: float | None = None  # CRF that gave best VMAF (from crf-search); fractional since ab-av1 0.11
     best_vmaf_achieved: float | None = None  # Best VMAF score we could achieve (from crf-search)
     predicted_output_size: int | None = None  # Predicted output size in bytes (from crf-search)
     predicted_size_reduction: float | None = None  # Predicted size reduction % (from crf-search)
@@ -382,7 +382,7 @@ class FileRecord:
     conversion_time_sec: float | None = None  # Legacy: combined time (for old records)
     crf_search_time_sec: float | None = None  # CRF search phase (ANALYZED, CONVERTED, NOT_WORTHWHILE)
     encoding_time_sec: float | None = None  # Encoding phase (CONVERTED only)
-    final_crf: int | None = None
+    final_crf: float | None = None
     final_vmaf: float | None = None
     vmaf_target_used: int | None = None
     output_audio_codec: str | None = None
@@ -437,7 +437,7 @@ class ProgressEvent:
 
     # Quality metrics (available during/after CRF search)
     vmaf: float | None = None  # VMAF score
-    crf: int | None = None  # CRF value
+    crf: float | None = None  # CRF value; fractional since ab-av1 0.11
     vmaf_target_used: int | None = None  # Target VMAF for this attempt
     used_fallback: bool | None = None  # Whether fallback VMAF was used (unused in progress)
 
@@ -531,7 +531,7 @@ class ConversionSessionState:
 
     # === Statistics Accumulators ===
     vmaf_scores: list[float] = field(default_factory=list)
-    crf_values: list[int] = field(default_factory=list)
+    crf_values: list[float] = field(default_factory=list)
     size_reductions: list[float] = field(default_factory=list)
     total_input_bytes_success: int = 0
     total_output_bytes_success: int = 0

--- a/src/utils.py
+++ b/src/utils.py
@@ -307,6 +307,65 @@ def check_ffmpeg_availability() -> tuple:
         return True, False, None, str(e)
 
 
+def parse_svt_av1_version(output: str) -> tuple[int, int] | None:
+    """Parse the SVT-AV1 library version from its encoder startup banner.
+
+    SVT-AV1 prints a line like "Svt[info]: SVT [version]:	SVT-AV1 Encoder Lib v4.1.0-259-gec17f8382"
+    when an encode starts. The library version is not available from `ffmpeg -version`.
+
+    Args:
+        output: Combined stdout/stderr of an ffmpeg run that initialized libsvtav1
+
+    Returns:
+        (major, minor) version tuple, or None if no banner was found
+    """
+    match = re.search(r"SVT-AV1 Encoder Lib v(\d+)\.(\d+)", output)
+    if match:
+        return int(match.group(1)), int(match.group(2))
+    return None
+
+
+def get_svt_av1_version() -> tuple[int, int] | None:
+    """Probe the SVT-AV1 library version bundled with the active FFmpeg.
+
+    Runs a 1-frame null encode so libsvtav1 prints its version banner. Works for any
+    FFmpeg source (vendored, system PATH) since the banner comes from the library itself.
+
+    Returns:
+        (major, minor) version tuple, or None if FFmpeg is missing or the probe failed
+    """
+    ffmpeg_path = get_ffmpeg_path()
+    if ffmpeg_path is None:
+        return None
+    cmd = [
+        str(ffmpeg_path),
+        "-hide_banner",
+        "-f",
+        "lavfi",
+        "-i",
+        "nullsrc=s=64x64",
+        "-frames:v",
+        "1",
+        "-c:v",
+        "libsvtav1",
+        "-f",
+        "null",
+        "-",
+    ]
+    try:
+        startupinfo, _ = get_windows_subprocess_startupinfo()
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, check=False, startupinfo=startupinfo, encoding="utf-8", timeout=15
+        )
+        return parse_svt_av1_version(result.stderr + result.stdout)
+    except subprocess.TimeoutExpired:
+        logger.warning("SVT-AV1 version probe timed out after 15s")
+        return None
+    except Exception:
+        logger.exception("SVT-AV1 version probe failed")
+        return None
+
+
 # GitHub API endpoints for FFmpeg builds
 FFMPEG_GYAN_GITHUB_API = "https://api.github.com/repos/GyanD/codexffmpeg/releases/latest"
 FFMPEG_BTBN_GITHUB_API = "https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/latest"

--- a/src/utils.py
+++ b/src/utils.py
@@ -134,6 +134,23 @@ def format_file_size(size_bytes: int) -> str:
     return f"{size_bytes / (1024**3):.2f} GB"
 
 
+def format_crf(crf: float | None) -> str:
+    """Format a CRF value for display: whole values as "23", fractional as "23.25".
+
+    ab-av1 0.11+ searches libsvtav1 in quarter-CRF steps, so CRF values may be
+    fractional. Whole-number floats must not render as "23.0".
+
+    Args:
+        crf: CRF value (integer or fractional), or None if not yet known
+
+    Returns:
+        Compact string representation without a trailing ".0", or "?" for None
+    """
+    if crf is None:
+        return "?"
+    return f"{crf:g}"
+
+
 # --- Video and FFmpeg Utilities ---
 
 

--- a/src/video_conversion.py
+++ b/src/video_conversion.py
@@ -30,7 +30,14 @@ from src.config import DEFAULT_ENCODING_PRESET, DEFAULT_VMAF_TARGET, MIN_OUTPUT_
 from src.history_index import get_history_index
 from src.models import FileStatus, OutputMode
 from src.privacy import anonymize_filename
-from src.utils import format_file_size, format_time, get_video_info, log_conversion_result, log_video_properties
+from src.utils import (
+    format_crf,
+    format_file_size,
+    format_time,
+    get_video_info,
+    log_conversion_result,
+    log_video_properties,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -232,7 +239,7 @@ def process_video(
             use_cached_crf = True
             cached_crf = record.best_crf
             logger.info(
-                f"Using cached CRF {cached_crf} for {anonymized_input_name} "
+                f"Using cached CRF {format_crf(cached_crf)} for {anonymized_input_name} "
                 f"(VMAF {record.vmaf_target_when_analyzed}, preset {record.preset_when_analyzed})"
             )
 
@@ -299,7 +306,8 @@ def process_video(
             final_vmaf_target = result_stats.get("vmaf_target_used") if result_stats else DEFAULT_VMAF_TARGET
         logger.info(
             f"Conversion successful - Final VMAF: {final_vmaf if final_vmaf else 'N/A'}, "
-            f"Final CRF: {final_crf if final_crf else 'N/A'} (Target VMAF: {final_vmaf_target})"
+            f"Final CRF: {format_crf(final_crf) if final_crf is not None else 'N/A'} "
+            f"(Target VMAF: {final_vmaf_target})"
         )
 
         # Check VMAF achieved vs target used (use a small tolerance)

--- a/tests/test_history_index.py
+++ b/tests/test_history_index.py
@@ -81,6 +81,24 @@ def test_save_load_roundtrip(history_file, index):
     assert reloaded.find_by_size(SIZE_BYTES) == [record]
 
 
+def test_save_load_roundtrip_preserves_fractional_crf(history_file, index):
+    # ab-av1 0.11+ finds fractional CRFs (0.25 steps) up to 70 for libsvtav1
+    record = make_record(
+        "/videos/movie.mkv",
+        status=FileStatus.ANALYZED,
+        best_crf=68.75,
+        best_vmaf_achieved=95.5,
+        predicted_size_reduction=40.0,
+    )
+    index.upsert(record)
+    index.save()
+
+    reloaded = HistoryIndex()
+    loaded = reloaded.get(record.path_hash)
+    assert loaded is not None
+    assert loaded.best_crf == 68.75
+
+
 def test_save_is_noop_when_not_dirty(history_file, index):
     index.get("0" * 16)  # Force load without mutating
     index.save()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -105,6 +105,41 @@ def test_best_crf_line_sets_crf_and_95_percent_quality():
     assert recorder.events[0].crf == 31
 
 
+def test_fractional_crf_vmaf_line_parses_quarter_step_value():
+    # ab-av1 0.11+ searches libsvtav1 in 0.25 CRF steps
+    parser, recorder = make_parser()
+    stats = make_stats()
+
+    parser.parse_line("crf 23.25 VMAF 96.50 (34%)", stats)
+
+    assert stats["crf"] == 23.25
+    assert stats["vmaf"] == 96.5
+    assert len(recorder.calls) == 1
+    assert recorder.events[0].message == "Detecting Quality (CRF:23.25, VMAF:96.5)"
+
+
+def test_fractional_sample_log_line_parses_crf_and_vmaf():
+    # RUST_LOG info line format fixed in ab-av1 0.11.4
+    parser, _ = make_parser()
+    stats = make_stats()
+
+    parser.parse_line("sample 3/5 crf 23.25 VMAF 95.11 (9%)", stats)
+
+    assert stats["crf"] == 23.25
+    assert stats["vmaf"] == 95.11
+
+
+def test_fractional_best_crf_line_is_not_truncated():
+    parser, recorder = make_parser()
+    stats = make_stats()
+
+    parser.parse_line("Best CRF: 23.25", stats)
+
+    assert stats["crf"] == 23.25
+    assert stats["progress_quality"] == 95.0
+    assert recorder.events[0].crf == 23.25
+
+
 def test_predicted_size_reduction_line_stores_reduction_without_callback():
     parser, recorder = make_parser()
     stats = make_stats()
@@ -335,3 +370,13 @@ def test_parse_line_without_callback_does_not_raise():
 
     assert stats["crf"] == 30
     assert stats["progress_quality"] == 95.0
+
+
+def test_parse_final_output_keeps_fractional_crf():
+    parser, _ = make_parser()
+    stats = make_stats()
+
+    parser.parse_final_output("Best CRF: 23.25\nVMAF 95.32\n", stats)
+
+    assert stats["crf"] == 23.25
+    assert stats["vmaf"] == 95.32

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,8 @@
 # tests/test_utils.py
-"""Tests for pure formatting helpers in src/utils.py."""
+"""Tests for pure formatting/parsing helpers in src/utils.py."""
 
 import pytest
-from src.utils import format_crf
+from src.utils import format_crf, parse_svt_av1_version
 
 
 @pytest.mark.parametrize(
@@ -10,3 +10,17 @@ from src.utils import format_crf
 )
 def test_format_crf(crf, expected):
     assert format_crf(crf) == expected
+
+
+@pytest.mark.parametrize(
+    ("output", "expected"),
+    [
+        # Real banner captured from Gyan FFmpeg 8.1.2 (dev build suffix after patch version)
+        ("Svt[info]: SVT [version]:\tSVT-AV1 Encoder Lib v4.1.0-259-gec17f8382", (4, 1)),
+        ("Svt[info]: SVT [version]:\tSVT-AV1 Encoder Lib v3.1.0", (3, 1)),
+        ("frame=1 fps=0.0 q=-0.0 size=0KiB time=00:00:00.00", None),
+        ("", None),
+    ],
+)
+def test_parse_svt_av1_version(output, expected):
+    assert parse_svt_av1_version(output) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,12 @@
+# tests/test_utils.py
+"""Tests for pure formatting helpers in src/utils.py."""
+
+import pytest
+from src.utils import format_crf
+
+
+@pytest.mark.parametrize(
+    ("crf", "expected"), [(23, "23"), (23.0, "23"), (23.25, "23.25"), (23.5, "23.5"), (68.75, "68.75"), (5, "5")]
+)
+def test_format_crf(crf, expected):
+    assert format_crf(crf) == expected


### PR DESCRIPTION
ab-av1 0.11.0 switched the default libsvtav1 crf-search to quarter-CRF steps (`--crf-increment 0.25`) over a widened [5, 70] range, so it now reports fractional CRFs like `23.25`. The vendored binary is already on 0.11.4, but the whole pipeline assumed integer CRF: the `crf (\d+) VMAF` regex failed to match fractional progress lines at all (progress updates silently dropped), `Best CRF: 23.25` was truncated to 23 by the capture group, storing a wrong CRF in history and feeding it into cached-CRF re-encodes, and two `int()` casts in the GUI layer truncated values for the statistics accumulator and the live settings label.

CRF is now a float end-to-end: parser regexes and casts, `ProgressEvent`/`FileRecord` fields, the worker's record builder, and `encode_with_crf` through to the `--crf` argument. `MAX_CRF_VALUE` rises from 63 to 70 so history validation accepts the new upper search range. A new `format_crf()` helper in `src/utils.py` renders whole values as `23` and fractional as `23.25` (never `23.0`) across the UI, logs, and CLI args. Existing history records with integer CRFs load unchanged.

Compatibility: fractional CRF requires FFmpeg with SVT-AV1 4.0 or newer. Older SVT (3.1, bundled in the previously vendored FFmpeg 8.0.1) silently truncates `crf=23.25` to 23, making quarter-step searches redundant. The startup dependency check now probes the SVT-AV1 library version (1-frame lavfi null encode — the version is not in `ffmpeg -version` output) and shows a warning directing the user to update FFmpeg from the Settings tab when it is older than 4.0.

Regression coverage: fractional `crf X VMAF Y`, `Best CRF:`, and 0.11.4 `sample x/n` log-line parsing; history round-trip preserving `68.75`; `format_crf` rendering; SVT-AV1 version banner parsing (including a real captured Gyan 8.1.2 banner).

Review order: `src/ab_av1/parser.py` (the actual fix), `src/utils.py` (`format_crf`, SVT version probe), then `models.py`/`worker.py`/`wrapper.py` type changes and the `gui_actions.py` startup guard; the remaining GUI files are mechanical display formatting.