### PR TITLE
fix(queue): Show skip reason on nested file rows instead of Done

### DIFF
--- a/src/conversion_engine/worker.py
+++ b/src/conversion_engine/worker.py
@@ -58,12 +58,16 @@ logger = logging.getLogger(__name__)
 # DO NOT use update_ui_safely() for every mutation - 100+ callbacks per file would tank performance.
 
 
-def _update_file_status(queue_item, file_index: int, status: QueueItemStatus, error_msg: str | None = None) -> None:
+def _update_file_status(
+    queue_item, file_index: int, status: QueueItemStatus, error_msg: str | None = None, skip_reason: str | None = None
+) -> None:
     """Update the status of a file within a folder queue item."""
     if queue_item.is_folder and file_index < len(queue_item.files):
         queue_item.files[file_index].status = status
         if error_msg:
             queue_item.files[file_index].error_message = error_msg
+        if skip_reason:
+            queue_item.files[file_index].skip_reason = skip_reason
     elif queue_item.is_folder:
         logger.warning(f"File index {file_index} out of range for queue item with {len(queue_item.files)} files")
 
@@ -545,7 +549,9 @@ def sequential_conversion_worker(
 
                     queue_item.processed_files += 1
                     queue_item.files_skipped += 1
-                    _update_file_status(queue_item, file_index, QueueItemStatus.COMPLETED)
+                    _update_file_status(
+                        queue_item, file_index, QueueItemStatus.COMPLETED, skip_reason=reason or "Skipped"
+                    )
                     queue_status_callback(
                         queue_item.id, QueueItemStatus.CONVERTING, queue_item.processed_files, queue_item.total_files
                     )
@@ -618,7 +624,7 @@ def sequential_conversion_worker(
                         file_event_callback(filename, "skipped", reason)
                         queue_item.processed_files += 1
                         queue_item.files_skipped += 1
-                        _update_file_status(queue_item, file_index, QueueItemStatus.COMPLETED)
+                        _update_file_status(queue_item, file_index, QueueItemStatus.COMPLETED, skip_reason=reason)
                         queue_status_callback(
                             queue_item.id,
                             QueueItemStatus.CONVERTING,
@@ -675,7 +681,12 @@ def sequential_conversion_worker(
                                     logger.info(f"Skipping {anonymized_name} - already converted")
                                     file_event_callback(filename, "skipped", "Already converted")
                                     queue_item.files_skipped += 1
-                                    _update_file_status(queue_item, file_index, QueueItemStatus.COMPLETED)
+                                    _update_file_status(
+                                        queue_item,
+                                        file_index,
+                                        QueueItemStatus.COMPLETED,
+                                        skip_reason="Already converted",
+                                    )
                                     queue_item.processed_files += 1
                                     queue_status_callback(
                                         queue_item.id,
@@ -697,7 +708,12 @@ def sequential_conversion_worker(
                                         cached_record.skip_reason or "Previously marked not worthwhile",
                                     )
                                     queue_item.files_skipped += 1
-                                    _update_file_status(queue_item, file_index, QueueItemStatus.COMPLETED)
+                                    _update_file_status(
+                                        queue_item,
+                                        file_index,
+                                        QueueItemStatus.COMPLETED,
+                                        skip_reason=cached_record.skip_reason or "Previously marked not worthwhile",
+                                    )
                                     queue_item.processed_files += 1
                                     queue_status_callback(
                                         queue_item.id,
@@ -716,7 +732,12 @@ def sequential_conversion_worker(
                                     logger.info(f"Skipping {anonymized_name} - already analyzed")
                                     file_event_callback(filename, "skipped", "Already analyzed")
                                     queue_item.files_skipped += 1
-                                    _update_file_status(queue_item, file_index, QueueItemStatus.COMPLETED)
+                                    _update_file_status(
+                                        queue_item,
+                                        file_index,
+                                        QueueItemStatus.COMPLETED,
+                                        skip_reason="Already analyzed",
+                                    )
                                     queue_item.processed_files += 1
                                     queue_status_callback(
                                         queue_item.id,
@@ -840,7 +861,7 @@ def sequential_conversion_worker(
                                 },
                             )
                             queue_item.files_skipped += 1
-                            _update_file_status(queue_item, file_index, QueueItemStatus.COMPLETED)
+                            _update_file_status(queue_item, file_index, QueueItemStatus.COMPLETED, skip_reason=str(e))
 
                             # Update analysis tree now that history is saved
                             update_ui_safely(
@@ -975,7 +996,9 @@ def sequential_conversion_worker(
                 # Check if this was a NOT_WORTHWHILE skip and record to history
                 elif gui.session.last_skip_reason:
                     queue_item.files_skipped += 1
-                    _update_file_status(queue_item, file_index, QueueItemStatus.COMPLETED)
+                    _update_file_status(
+                        queue_item, file_index, QueueItemStatus.COMPLETED, skip_reason=gui.session.last_skip_reason
+                    )
 
                     # Capture skip data and timing before clearing
                     skip_reason = gui.session.last_skip_reason

--- a/src/conversion_engine/worker.py
+++ b/src/conversion_engine/worker.py
@@ -63,11 +63,18 @@ def _update_file_status(
 ) -> None:
     """Update the status of a file within a folder queue item."""
     if queue_item.is_folder and file_index < len(queue_item.files):
-        queue_item.files[file_index].status = status
+        file_item = queue_item.files[file_index]
+        file_item.status = status
+        if status == QueueItemStatus.CONVERTING:
+            # Fresh processing attempt - stale outcome fields from a prior pass
+            # would mislabel the new result (e.g. a successful conversion
+            # rendered as "Skipped: ...")
+            file_item.skip_reason = None
+            file_item.error_message = None
         if error_msg:
-            queue_item.files[file_index].error_message = error_msg
+            file_item.error_message = error_msg
         if skip_reason:
-            queue_item.files[file_index].skip_reason = skip_reason
+            file_item.skip_reason = skip_reason
     elif queue_item.is_folder:
         logger.warning(f"File index {file_index} out of range for queue item with {len(queue_item.files)} files")
 
@@ -678,14 +685,12 @@ def sequential_conversion_worker(
                             # output at the input path, which would otherwise be CRF-searched)
                             if cached_record.status == FileStatus.CONVERTED:
                                 if converted_verdict_applies(cached_record, file_path):
-                                    logger.info(f"Skipping {anonymized_name} - already converted")
-                                    file_event_callback(filename, "skipped", "Already converted")
+                                    reason = "Already converted"
+                                    logger.info(f"Skipping {anonymized_name} - {reason}")
+                                    file_event_callback(filename, "skipped", reason)
                                     queue_item.files_skipped += 1
                                     _update_file_status(
-                                        queue_item,
-                                        file_index,
-                                        QueueItemStatus.COMPLETED,
-                                        skip_reason="Already converted",
+                                        queue_item, file_index, QueueItemStatus.COMPLETED, skip_reason=reason
                                     )
                                     queue_item.processed_files += 1
                                     queue_status_callback(
@@ -701,18 +706,12 @@ def sequential_conversion_worker(
                             # Skip NOT_WORTHWHILE files - already determined conversion isn't beneficial
                             elif cached_record.status == FileStatus.NOT_WORTHWHILE:
                                 if is_file_unchanged(cached_record, file_path):
+                                    reason = cached_record.skip_reason or "Previously marked not worthwhile"
                                     logger.info(f"Skipping {anonymized_name} - previously marked not worthwhile")
-                                    file_event_callback(
-                                        filename,
-                                        "skipped",
-                                        cached_record.skip_reason or "Previously marked not worthwhile",
-                                    )
+                                    file_event_callback(filename, "skipped", reason)
                                     queue_item.files_skipped += 1
                                     _update_file_status(
-                                        queue_item,
-                                        file_index,
-                                        QueueItemStatus.COMPLETED,
-                                        skip_reason=cached_record.skip_reason or "Previously marked not worthwhile",
+                                        queue_item, file_index, QueueItemStatus.COMPLETED, skip_reason=reason
                                     )
                                     queue_item.processed_files += 1
                                     queue_status_callback(
@@ -729,14 +728,12 @@ def sequential_conversion_worker(
                             # Skip ANALYZED files - already have Layer 2 data (CRF search complete)
                             elif cached_record.status == FileStatus.ANALYZED:
                                 if is_file_unchanged(cached_record, file_path):
-                                    logger.info(f"Skipping {anonymized_name} - already analyzed")
-                                    file_event_callback(filename, "skipped", "Already analyzed")
+                                    reason = "Already analyzed"
+                                    logger.info(f"Skipping {anonymized_name} - {reason}")
+                                    file_event_callback(filename, "skipped", reason)
                                     queue_item.files_skipped += 1
                                     _update_file_status(
-                                        queue_item,
-                                        file_index,
-                                        QueueItemStatus.COMPLETED,
-                                        skip_reason="Already analyzed",
+                                        queue_item, file_index, QueueItemStatus.COMPLETED, skip_reason=reason
                                     )
                                     queue_item.processed_files += 1
                                     queue_status_callback(

--- a/src/gui/conversion_controller.py
+++ b/src/gui/conversion_controller.py
@@ -52,6 +52,7 @@ from src.gui.gui_updates import (
     update_total_elapsed_time,
     update_total_remaining_time,
 )
+from src.gui.tree_display import QUEUE_STATUS_TAGS, format_queue_file_status
 from src.models import OutputMode, QueueConversionConfig, QueueItemStatus
 
 # Import from utils and other modules
@@ -123,14 +124,6 @@ def create_queue_status_callback(gui):
     Returns:
         A callback function that updates queue tree rows
     """
-    # Status tag mapping for file rows
-    file_status_tags = {
-        QueueItemStatus.PENDING: "file_pending",
-        QueueItemStatus.CONVERTING: "file_converting",
-        QueueItemStatus.COMPLETED: "file_done",
-        QueueItemStatus.STOPPED: "file_skipped",
-        QueueItemStatus.ERROR: "file_error",
-    }
 
     def queue_status_callback(queue_item_id: str, status: QueueItemStatus, processed: int, total: int):
         """Update queue tree with item status.
@@ -159,7 +152,7 @@ def create_queue_status_callback(gui):
                     gui.queue_tree.set(tree_id, "status", status_display)
 
                     # Update root queue item tags to match status
-                    tag = file_status_tags.get(status, "file_pending")
+                    tag = QUEUE_STATUS_TAGS.get(status, "file_pending")
                     gui.queue_tree.item(tree_id, tags=(tag,))
                 except Exception:
                     logger.debug(f"Could not update tree row for {queue_item_id}")
@@ -170,22 +163,13 @@ def create_queue_status_callback(gui):
                     file_tree_id = gui.get_file_tree_id(file_item.path)
                     if file_tree_id:
                         try:
-                            # Format file status text
-                            if file_item.status == QueueItemStatus.COMPLETED:
-                                file_status = "Done"
-                            elif file_item.status == QueueItemStatus.CONVERTING:
-                                file_status = "Converting..."
-                            elif file_item.status == QueueItemStatus.ERROR:
-                                file_status = file_item.error_message or "Error"
-                            elif file_item.status == QueueItemStatus.STOPPED:
-                                file_status = "Stopped"
-                            else:
-                                file_status = ""
-
-                            gui.queue_tree.set(file_tree_id, "status", file_status)
-                            gui.queue_tree.item(
-                                file_tree_id, tags=(file_status_tags.get(file_item.status, "file_pending"),)
+                            file_status, file_tag = format_queue_file_status(
+                                file_item.status,
+                                error_message=file_item.error_message,
+                                skip_reason=file_item.skip_reason,
                             )
+                            gui.queue_tree.set(file_tree_id, "status", file_status)
+                            gui.queue_tree.item(file_tree_id, tags=(file_tag,))
                         except Exception:
                             logger.debug(f"Could not update file tree row for {file_item.path}")
 

--- a/src/gui/queue_manager.py
+++ b/src/gui/queue_manager.py
@@ -93,13 +93,16 @@ def _reconcile_folder_files(item: QueueItem, index) -> None:
             item.processed_files += 1
             # Categorize outcome
             if record.status == FileStatus.NOT_WORTHWHILE:
+                file_item.skip_reason = record.skip_reason or "Not worth converting"
                 item.files_skipped += 1
             else:
+                file_item.skip_reason = None
                 item.files_succeeded += 1
         else:
             # No history record, file changed, or not in terminal state - needs processing
             file_item.status = QueueItemStatus.PENDING
             file_item.error_message = None
+            file_item.skip_reason = None
             pending_count += 1
 
     # Update total_files to match actual file list

--- a/src/gui/queue_tree.py
+++ b/src/gui/queue_tree.py
@@ -390,6 +390,7 @@ def _build_file_values(
         file_item.status,
         stopping=stopping,
         error_message=file_item.error_message,
+        skip_reason=file_item.skip_reason,
     )
 
     return (file_format, file_size, file_est_time, "", "", file_status), file_tag

--- a/src/gui/tree_display.py
+++ b/src/gui/tree_display.py
@@ -87,6 +87,7 @@ def format_queue_file_status(
     *,
     stopping: bool = False,
     error_message: str | None = None,
+    skip_reason: str | None = None,
 ) -> tuple[str, str]:
     """Format queue file item status for display (nested files in folder items).
 
@@ -94,6 +95,7 @@ def format_queue_file_status(
         status: The file item status.
         stopping: Whether a stop has been requested.
         error_message: Error message if status is ERROR.
+        skip_reason: Skip reason if the file completed by being skipped.
 
     Returns:
         Tuple of (display_text, tag_name).
@@ -105,6 +107,8 @@ def format_queue_file_status(
     tag = QUEUE_STATUS_TAGS.get(status, "file_pending")
 
     if status == QueueItemStatus.COMPLETED:
+        if skip_reason:
+            return f"Skipped: {skip_reason}", "file_skipped"
         return "Done", tag
     if status == QueueItemStatus.CONVERTING:
         return "Converting...", tag

--- a/src/models.py
+++ b/src/models.py
@@ -198,6 +198,7 @@ class QueueFileItem:
     status: QueueItemStatus = QueueItemStatus.PENDING
     size_bytes: int = 0
     error_message: str | None = None
+    skip_reason: str | None = None  # Why the file was skipped (distinguishes skips from successes)
 
 
 @dataclass
@@ -245,7 +246,13 @@ class QueueItem:
             "files_failed": self.files_failed,
             "last_error": self.last_error,
             "files": [
-                {"path": f.path, "status": f.status.value, "size_bytes": f.size_bytes, "error_message": f.error_message}
+                {
+                    "path": f.path,
+                    "status": f.status.value,
+                    "size_bytes": f.size_bytes,
+                    "error_message": f.error_message,
+                    "skip_reason": f.skip_reason,
+                }
                 for f in self.files
             ],
             "current_file_index": self.current_file_index,
@@ -261,6 +268,7 @@ class QueueItem:
                 status=QueueItemStatus(f.get("status", "pending")),
                 size_bytes=f.get("size_bytes", 0),
                 error_message=f.get("error_message"),
+                skip_reason=f.get("skip_reason"),
             )
             for f in files_data
         ]

--- a/tests/test_tree_display.py
+++ b/tests/test_tree_display.py
@@ -1,0 +1,67 @@
+# tests/test_tree_display.py
+"""Tests for queue file status formatting and skip reason persistence."""
+
+from src.gui.tree_display import format_queue_file_status
+from src.models import QueueFileItem, QueueItem, QueueItemStatus
+
+
+class TestFormatQueueFileStatus:
+    def test_completed_without_skip_reason_shows_done(self):
+        text, tag = format_queue_file_status(QueueItemStatus.COMPLETED)
+        assert text == "Done"
+        assert tag == "file_done"
+
+    def test_completed_with_skip_reason_shows_skipped(self):
+        text, tag = format_queue_file_status(
+            QueueItemStatus.COMPLETED, skip_reason="Not worth converting (VMAF 95 unattainable)"
+        )
+        assert text == "Skipped: Not worth converting (VMAF 95 unattainable)"
+        assert tag == "file_skipped"
+
+    def test_error_shows_error_message(self):
+        text, tag = format_queue_file_status(QueueItemStatus.ERROR, error_message="Disk full")
+        assert text == "Disk full"
+        assert tag == "file_error"
+
+    def test_skip_reason_ignored_for_non_completed_statuses(self):
+        text, tag = format_queue_file_status(QueueItemStatus.CONVERTING, skip_reason="stale")
+        assert text == "Converting..."
+        assert tag == "file_converting"
+
+    def test_stopping_pending_shows_will_skip(self):
+        text, tag = format_queue_file_status(QueueItemStatus.PENDING, stopping=True)
+        assert text == "Will skip"
+        assert tag == "file_skipped"
+
+
+class TestQueueFileItemSerialization:
+    def test_skip_reason_round_trips(self):
+        item = QueueItem(
+            id="test-id",
+            source_path="/videos",
+            is_folder=True,
+            files=[
+                QueueFileItem(
+                    path="/videos/a.mp4",
+                    status=QueueItemStatus.COMPLETED,
+                    size_bytes=100,
+                    skip_reason="Already converted",
+                ),
+                QueueFileItem(path="/videos/b.mp4", status=QueueItemStatus.COMPLETED, size_bytes=200),
+            ],
+        )
+
+        restored = QueueItem.from_dict(item.to_dict())
+
+        assert restored.files[0].skip_reason == "Already converted"
+        assert restored.files[1].skip_reason is None
+
+    def test_missing_skip_reason_key_defaults_to_none(self):
+        data = QueueItem(
+            id="test-id", source_path="/videos", is_folder=True, files=[QueueFileItem(path="/videos/a.mp4")]
+        ).to_dict()
+        del data["files"][0]["skip_reason"]
+
+        restored = QueueItem.from_dict(data)
+
+        assert restored.files[0].skip_reason is None

--- a/tests/test_tree_display.py
+++ b/tests/test_tree_display.py
@@ -4,64 +4,67 @@
 from src.gui.tree_display import format_queue_file_status
 from src.models import QueueFileItem, QueueItem, QueueItemStatus
 
-
-class TestFormatQueueFileStatus:
-    def test_completed_without_skip_reason_shows_done(self):
-        text, tag = format_queue_file_status(QueueItemStatus.COMPLETED)
-        assert text == "Done"
-        assert tag == "file_done"
-
-    def test_completed_with_skip_reason_shows_skipped(self):
-        text, tag = format_queue_file_status(
-            QueueItemStatus.COMPLETED, skip_reason="Not worth converting (VMAF 95 unattainable)"
-        )
-        assert text == "Skipped: Not worth converting (VMAF 95 unattainable)"
-        assert tag == "file_skipped"
-
-    def test_error_shows_error_message(self):
-        text, tag = format_queue_file_status(QueueItemStatus.ERROR, error_message="Disk full")
-        assert text == "Disk full"
-        assert tag == "file_error"
-
-    def test_skip_reason_ignored_for_non_completed_statuses(self):
-        text, tag = format_queue_file_status(QueueItemStatus.CONVERTING, skip_reason="stale")
-        assert text == "Converting..."
-        assert tag == "file_converting"
-
-    def test_stopping_pending_shows_will_skip(self):
-        text, tag = format_queue_file_status(QueueItemStatus.PENDING, stopping=True)
-        assert text == "Will skip"
-        assert tag == "file_skipped"
+# ---------------------------------------------------------------------------
+# format_queue_file_status
+# ---------------------------------------------------------------------------
 
 
-class TestQueueFileItemSerialization:
-    def test_skip_reason_round_trips(self):
-        item = QueueItem(
-            id="test-id",
-            source_path="/videos",
-            is_folder=True,
-            files=[
-                QueueFileItem(
-                    path="/videos/a.mp4",
-                    status=QueueItemStatus.COMPLETED,
-                    size_bytes=100,
-                    skip_reason="Already converted",
-                ),
-                QueueFileItem(path="/videos/b.mp4", status=QueueItemStatus.COMPLETED, size_bytes=200),
-            ],
-        )
+def test_completed_without_skip_reason_shows_done():
+    assert format_queue_file_status(QueueItemStatus.COMPLETED) == ("Done", "file_done")
 
-        restored = QueueItem.from_dict(item.to_dict())
 
-        assert restored.files[0].skip_reason == "Already converted"
-        assert restored.files[1].skip_reason is None
+def test_completed_with_skip_reason_shows_skipped():
+    text, tag = format_queue_file_status(
+        QueueItemStatus.COMPLETED, skip_reason="Not worth converting (VMAF 95 unattainable)"
+    )
+    assert text == "Skipped: Not worth converting (VMAF 95 unattainable)"
+    assert tag == "file_skipped"
 
-    def test_missing_skip_reason_key_defaults_to_none(self):
-        data = QueueItem(
-            id="test-id", source_path="/videos", is_folder=True, files=[QueueFileItem(path="/videos/a.mp4")]
-        ).to_dict()
-        del data["files"][0]["skip_reason"]
 
-        restored = QueueItem.from_dict(data)
+def test_error_shows_error_message():
+    assert format_queue_file_status(QueueItemStatus.ERROR, error_message="Disk full") == ("Disk full", "file_error")
 
-        assert restored.files[0].skip_reason is None
+
+def test_skip_reason_ignored_for_non_completed_statuses():
+    assert format_queue_file_status(QueueItemStatus.CONVERTING, skip_reason="stale") == (
+        "Converting...",
+        "file_converting",
+    )
+
+
+def test_stopping_pending_shows_will_skip():
+    assert format_queue_file_status(QueueItemStatus.PENDING, stopping=True) == ("Will skip", "file_skipped")
+
+
+# ---------------------------------------------------------------------------
+# QueueFileItem skip_reason serialization
+# ---------------------------------------------------------------------------
+
+
+def _folder_item(files: list[QueueFileItem]) -> QueueItem:
+    return QueueItem(id="test-id", source_path="/videos", is_folder=True, files=files)
+
+
+def test_skip_reason_round_trips():
+    item = _folder_item(
+        [
+            QueueFileItem(
+                path="/videos/a.mp4", status=QueueItemStatus.COMPLETED, size_bytes=100, skip_reason="Already converted"
+            ),
+            QueueFileItem(path="/videos/b.mp4", status=QueueItemStatus.COMPLETED, size_bytes=200),
+        ]
+    )
+
+    restored = QueueItem.from_dict(item.to_dict())
+
+    assert restored.files[0].skip_reason == "Already converted"
+    assert restored.files[1].skip_reason is None
+
+
+def test_missing_skip_reason_key_defaults_to_none():
+    data = _folder_item([QueueFileItem(path="/videos/a.mp4")]).to_dict()
+    del data["files"][0]["skip_reason"]
+
+    restored = QueueItem.from_dict(data)
+
+    assert restored.files[0].skip_reason is None


### PR DESCRIPTION
Skipped files nested inside folder queue items now display "Skipped: <reason>" with the skipped-row styling instead of "Done", both live during a run and after restart, so they are distinguishable from successful conversions. The parent folder row already showed aggregate skip counts (e.g. "Done (3✓ 1⊘)"), but individual file rows carried no skip information.

Root cause: `QueueFileItem` only tracked `status` and `error_message`, and every skip path in the worker (not worthwhile, already converted, already analyzed, duplicate of another path, below minimum resolution) marked the file plain `COMPLETED`. Each of those sites already had a human-readable reason in hand for the log callback and then dropped it.

The fix adds a `skip_reason` field mirroring the `error_message` pattern:

- The worker records the reason at all seven skip sites, and clears both `skip_reason` and `error_message` when a file enters `CONVERTING`, so a file skipped in one pass that later converts successfully (restart with a changed VMAF target, replaced file on disk) cannot keep a stale "Skipped:" label.
- Nested file rows were rendered by two independent code paths: `_build_file_values` in `queue_tree.py` and an inline copy in the live queue status callback in `conversion_controller.py`. Without unifying them the live path would have kept showing "Done" for the entire run. Both now go through the shared `format_queue_file_status()`, and the callback's private status-tag dict is replaced by the shared `QUEUE_STATUS_TAGS`.
- Queue persistence round-trips the field (old configs without the key load as `None`), and startup reconciliation restores it from history for NOT_WORTHWHILE records while clearing it for successes and re-pended files.

Skip reason strings are short path-free literals (scanner reasons, ab-av1 "no efficient conversion" messages, duplicate-of variants), so nothing new leaks into the persisted queue config. Review order: `tree_display.py` (formatter), then `worker.py` (skip sites and the CONVERTING reset), then `conversion_controller.py` (deduped render path). New tests cover the formatter branches and the serialization round trip.

Fixes #7
