### PR TITLE
fix(gui): Show consistent time estimates in Analysis and Queue tabs

### DIFF
--- a/src/estimation.py
+++ b/src/estimation.py
@@ -15,6 +15,7 @@ import time
 from collections import defaultdict
 from typing import Any
 
+from src.cache_helpers import is_file_unchanged
 from src.config import MIN_SAMPLES_FOR_ESTIMATE, MIN_SAMPLES_HIGH_CONFIDENCE
 from src.history_index import get_history_index
 from src.models import OperationType, TimeEstimate
@@ -235,6 +236,39 @@ def estimate_file_time(
 
     # Tier 4: Insufficient data
     return TimeEstimate(0, 0, 0, "none", "insufficient_data")
+
+
+def estimate_fresh_file_time(
+    file_path: str, *, operation_type: OperationType | None = None, grouped_percentiles: dict | None = None
+) -> TimeEstimate:
+    """Estimate processing time from history, but only while the record is fresh.
+
+    Shared display rule for the Analysis and Queue tabs: a time estimate is shown
+    only when a history record exists AND still describes the file on disk
+    (size + mtime match). A stale record's metadata may no longer be accurate,
+    so both tabs show "—" instead of a confident-looking number.
+
+    Args:
+        file_path: Path to the file.
+        operation_type: If ANALYZE, estimates CRF search time only (no encoding).
+        grouped_percentiles: Pre-computed percentiles from compute_grouped_percentiles().
+
+    Returns:
+        TimeEstimate from the record's metadata, or "none" confidence when the
+        record is missing or stale.
+    """
+    record = get_history_index().lookup_file(file_path)
+    if record is None or not is_file_unchanged(record, file_path):
+        return TimeEstimate(0, 0, 0, "none", "no_fresh_record")
+
+    return estimate_file_time(
+        codec=record.video_codec,
+        duration=record.duration_sec,
+        width=record.width,
+        height=record.height,
+        operation_type=operation_type,
+        grouped_percentiles=grouped_percentiles,
+    )
 
 
 def estimate_current_file_eta(

--- a/src/gui/analysis_controller.py
+++ b/src/gui/analysis_controller.py
@@ -588,24 +588,24 @@ def update_total_from_tree(gui) -> int:
             done_count += 1
         elif record.status == FileStatus.NOT_WORTHWHILE:
             skip_count += 1
-        else:
-            # Use Layer 2 data if available, otherwise fall back to Layer 1 estimate
+        elif record.status in (FileStatus.SCANNED, FileStatus.ANALYZED):
+            convertible += 1
+            # Track if this file only has ffprobe-level analysis (no CRF search)
+            if record.predicted_size_reduction is None:
+                any_estimate = True
+            # Savings needs a reduction estimate; use Layer 2 data if available,
+            # otherwise fall back to Layer 1 estimate
             reduction_percent = record.predicted_size_reduction or record.estimated_reduction_percent
-            if record.status in (FileStatus.SCANNED, FileStatus.ANALYZED) and reduction_percent:
-                convertible += 1
-                # Track if this file only has ffprobe-level analysis (no CRF search)
-                if record.predicted_size_reduction is None:
-                    any_estimate = True
-                if record.file_size_bytes:
-                    total_savings += int(record.file_size_bytes * reduction_percent / 100)
-                file_time = estimate_file_time(
-                    codec=record.video_codec,
-                    duration=record.duration_sec,
-                    width=record.width,
-                    height=record.height,
-                    grouped_percentiles=grouped_percentiles,
-                ).best_seconds
-                total_time += file_time
+            if reduction_percent and record.file_size_bytes:
+                total_savings += int(record.file_size_bytes * reduction_percent / 100)
+            # Time needs only codec/duration/resolution - independent of savings
+            total_time += estimate_file_time(
+                codec=record.video_codec,
+                duration=record.duration_sec,
+                width=record.width,
+                height=record.height,
+                grouped_percentiles=grouped_percentiles,
+            ).best_seconds
 
     update_total_row(
         gui, total_files, convertible, done_count, skip_count, total_size, total_savings, total_time, any_estimate

--- a/src/gui/analysis_tree.py
+++ b/src/gui/analysis_tree.py
@@ -191,28 +191,26 @@ def update_folder_aggregates(
             if record.file_size_bytes:
                 total_size += record.file_size_bytes
 
-            # Check if file needs conversion and has estimates
-            # Use Layer 2 data if available, otherwise fall back to Layer 1 estimate
-            reduction_percent = record.predicted_size_reduction or record.estimated_reduction_percent
-            if record.status in (FileStatus.SCANNED, FileStatus.ANALYZED) and reduction_percent:
+            # Check if file needs conversion
+            if record.status in (FileStatus.SCANNED, FileStatus.ANALYZED):
                 # Track if this file only has ffprobe-level analysis (no CRF search)
                 if record.predicted_size_reduction is None:
                     any_estimate = True
 
-                # Calculate savings from reduction percentage
-                if record.file_size_bytes:
-                    file_savings = int(record.file_size_bytes * reduction_percent / 100)
-                    total_savings += file_savings
+                # Savings needs a reduction estimate; use Layer 2 data if
+                # available, otherwise fall back to Layer 1 estimate
+                reduction_percent = record.predicted_size_reduction or record.estimated_reduction_percent
+                if reduction_percent and record.file_size_bytes:
+                    total_savings += int(record.file_size_bytes * reduction_percent / 100)
 
-                # Get time estimate
-                file_time = estimate_file_time(
+                # Time needs only codec/duration/resolution - independent of savings
+                total_time += estimate_file_time(
                     codec=record.video_codec,
                     duration=record.duration_sec,
                     width=record.width,
                     height=record.height,
                     grouped_percentiles=grouped_percentiles,
                 ).best_seconds
-                total_time += file_time
         else:
             # Child is a subfolder - read its cached aggregates
             folder_agg = gui.folder_aggregates.get(child_id)

--- a/src/gui/queue_tree.py
+++ b/src/gui/queue_tree.py
@@ -19,7 +19,7 @@ import contextlib
 import logging
 import os
 
-from src.estimation import compute_grouped_percentiles, estimate_file_time
+from src.estimation import compute_grouped_percentiles, estimate_fresh_file_time
 from src.gui.queue_controller import (
     update_clear_completed_button_state,
     update_remove_button_state,
@@ -317,7 +317,7 @@ def _display_context(gui) -> tuple[bool, object, dict, dict[str, TimeEstimate]]:
             percentiles = percentiles_by_op.get(op_type)
             for file_item in queue_item.files:
                 if file_item.path not in file_estimates:
-                    file_estimates[file_item.path] = estimate_file_time(
+                    file_estimates[file_item.path] = estimate_fresh_file_time(
                         file_item.path, operation_type=op_type, grouped_percentiles=percentiles
                     )
 
@@ -345,7 +345,7 @@ def _build_item_values(
     size_display = _format_size_display(queue_item, record)
 
     # Format estimated time
-    est_time_display = _format_time_estimate(queue_item, record, index, percentiles_by_op, file_estimates)
+    est_time_display = _format_time_estimate(queue_item, percentiles_by_op, file_estimates)
 
     # Format status with tag
     status_display, item_tag = format_queue_status_display(
@@ -473,9 +473,7 @@ def _format_size_display(queue_item, record) -> str:
         return "—"
 
 
-def _format_time_estimate(
-    queue_item, record, index, percentiles_by_op: dict, file_estimates: dict[str, TimeEstimate]
-) -> str:
+def _format_time_estimate(queue_item, percentiles_by_op: dict, file_estimates: dict[str, TimeEstimate]) -> str:
     """Format the estimated time column display text."""
     op_type = queue_item.operation_type
     percentiles = percentiles_by_op.get(op_type)
@@ -488,7 +486,7 @@ def _format_time_estimate(
             # Use pre-computed estimate from cache
             file_estimate = file_estimates.get(file_item.path)
             if file_estimate is None:
-                file_estimate = estimate_file_time(
+                file_estimate = estimate_fresh_file_time(
                     file_item.path, operation_type=op_type, grouped_percentiles=percentiles
                 )
             if file_estimate.confidence != "none" and file_estimate.best_seconds > 0:
@@ -498,22 +496,8 @@ def _format_time_estimate(
         if total_seconds > 0:
             return format_compact_time(total_seconds, confidence=lowest_confidence)
         return "—"
-    if record:
-        # Use record data for single file estimate
-        file_estimate = estimate_file_time(
-            codec=record.video_codec,
-            duration=record.duration_sec,
-            width=record.width,
-            height=record.height,
-            operation_type=op_type,
-            grouped_percentiles=percentiles,
-        )
-        if file_estimate.confidence != "none" and file_estimate.best_seconds > 0:
-            return format_compact_time(file_estimate.best_seconds, confidence=file_estimate.confidence)
-        return "—"
     if not queue_item.is_folder:
-        # Try path-based estimate as fallback (only for files, not folders)
-        file_estimate = estimate_file_time(
+        file_estimate = estimate_fresh_file_time(
             queue_item.source_path, operation_type=op_type, grouped_percentiles=percentiles
         )
         if file_estimate.confidence != "none" and file_estimate.best_seconds > 0:
@@ -566,7 +550,7 @@ def _update_total_row(
                 # Use pre-computed estimate from cache
                 file_estimate = file_estimates.get(file_item.path)
                 if file_estimate is None:
-                    file_estimate = estimate_file_time(
+                    file_estimate = estimate_fresh_file_time(
                         file_item.path, operation_type=op_type, grouped_percentiles=percentiles
                     )
                 if file_estimate.confidence != "none" and file_estimate.best_seconds > 0:
@@ -584,19 +568,9 @@ def _update_total_row(
                     total_size_bytes += os.path.getsize(queue_item.source_path)
 
             # Time estimate
-            if record:
-                file_estimate = estimate_file_time(
-                    codec=record.video_codec,
-                    duration=record.duration_sec,
-                    width=record.width,
-                    height=record.height,
-                    operation_type=op_type,
-                    grouped_percentiles=percentiles,
-                )
-            else:
-                file_estimate = estimate_file_time(
-                    queue_item.source_path, operation_type=op_type, grouped_percentiles=percentiles
-                )
+            file_estimate = estimate_fresh_file_time(
+                queue_item.source_path, operation_type=op_type, grouped_percentiles=percentiles
+            )
             if file_estimate.confidence != "none" and file_estimate.best_seconds > 0:
                 total_est_seconds += file_estimate.best_seconds
                 if confidence_order.get(file_estimate.confidence, 3) > confidence_order.get(lowest_confidence, 0):

--- a/src/gui/tree_display.py
+++ b/src/gui/tree_display.py
@@ -184,26 +184,26 @@ def compute_analysis_display_values(
         has_layer2 = record.predicted_size_reduction is not None
         reduction_percent = record.predicted_size_reduction or record.estimated_reduction_percent
 
+        # Time needs only codec/duration/resolution - independent of the savings inputs
+        if grouped_percentiles is None:
+            grouped_percentiles = compute_grouped_percentiles()
+
+        time_estimate = estimate_file_time(
+            codec=record.video_codec,
+            duration=record.duration_sec,
+            width=record.width,
+            height=record.height,
+            grouped_percentiles=grouped_percentiles,
+        )
+        # Layer 2 = precise (no prefix), Layer 1 = use estimate confidence
+        confidence = "high" if has_layer2 else time_estimate.confidence
+        time_str = format_compact_time(time_estimate.best_seconds, confidence=confidence)
+
         if reduction_percent and record.file_size_bytes:
             file_savings = int(record.file_size_bytes * reduction_percent / 100)
             savings_str = format_file_size(file_savings)
             if not has_layer2:
                 savings_str = f"~{savings_str}"
-
-            # Use pre-computed percentiles if provided, otherwise compute
-            if grouped_percentiles is None:
-                grouped_percentiles = compute_grouped_percentiles()
-
-            time_estimate = estimate_file_time(
-                codec=record.video_codec,
-                duration=record.duration_sec,
-                width=record.width,
-                height=record.height,
-                grouped_percentiles=grouped_percentiles,
-            )
-            # Layer 2 = precise (no prefix), Layer 1 = use estimate confidence
-            confidence = "high" if has_layer2 else time_estimate.confidence
-            time_str = format_compact_time(time_estimate.best_seconds, confidence=confidence)
             eff_str = format_efficiency(file_savings, time_estimate.best_seconds)
 
     return format_str, size_str, savings_str, time_str, eff_str, tag

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -1,15 +1,23 @@
 # tests/test_estimation.py
 """Characterization tests for the pure math in src/estimation.py.
 
-Functions needing get_history_index() or a gui object (compute_grouped_*,
+Functions needing a real history index or a gui object (compute_grouped_*,
 estimate_pending_files_eta, estimate_remaining_time) are not covered;
 estimate_file_time is exercised only with explicit metadata and pre-computed
-percentiles so the history index is never touched.
+percentiles, and estimate_fresh_file_time with a faked-out index.
 """
 
 import time
 
-from src.estimation import compute_percentiles, estimate_current_file_eta, estimate_file_time, get_resolution_bucket
+from src.estimation import (
+    compute_percentiles,
+    estimate_current_file_eta,
+    estimate_file_time,
+    estimate_fresh_file_time,
+    get_resolution_bucket,
+)
+from src.history_index import compute_path_hash
+from src.models import FileRecord, FileStatus
 
 # ---------------------------------------------------------------------------
 # get_resolution_bucket
@@ -118,6 +126,70 @@ def test_unknown_resolution_skips_tier1():
         codec="h264", duration=600.0, grouped_percentiles={("h264", "unknown"): STATS_10, ("h264", None): STATS_5}
     )
     assert estimate.source == "codec:h264"
+
+
+# ---------------------------------------------------------------------------
+# estimate_fresh_file_time (freshness-gated display rule, issue #6)
+# ---------------------------------------------------------------------------
+
+
+class FakeIndex:
+    def __init__(self, record):
+        self._record = record
+
+    def lookup_file(self, file_path):
+        return self._record
+
+
+def make_video_file(tmp_path):
+    file_path = tmp_path / "video.mp4"
+    file_path.write_bytes(b"x" * 100)
+    return file_path
+
+
+def make_record(file_path, size_bytes, mtime):
+    return FileRecord(
+        path_hash=compute_path_hash(str(file_path)),
+        original_path=None,
+        status=FileStatus.SCANNED,
+        file_size_bytes=size_bytes,
+        file_mtime=mtime,
+        duration_sec=600.0,
+        video_codec="h264",
+        width=1920,
+        height=1080,
+    )
+
+
+def test_fresh_record_yields_estimate(tmp_path, monkeypatch):
+    file_path = make_video_file(tmp_path)
+    stat = file_path.stat()
+    record = make_record(file_path, stat.st_size, stat.st_mtime)
+    monkeypatch.setattr("src.estimation.get_history_index", lambda: FakeIndex(record))
+
+    estimate = estimate_fresh_file_time(str(file_path), grouped_percentiles={("h264", "1080p"): STATS_10})
+    assert estimate.confidence == "high"
+    assert estimate.best_seconds == 1200.0
+
+
+def test_stale_record_returns_none_confidence(tmp_path, monkeypatch):
+    file_path = make_video_file(tmp_path)
+    stat = file_path.stat()
+    record = make_record(file_path, stat.st_size + 1, stat.st_mtime)  # size no longer matches disk
+    monkeypatch.setattr("src.estimation.get_history_index", lambda: FakeIndex(record))
+
+    estimate = estimate_fresh_file_time(str(file_path), grouped_percentiles={("h264", "1080p"): STATS_10})
+    assert estimate.confidence == "none"
+    assert estimate.source == "no_fresh_record"
+
+
+def test_missing_record_returns_none_confidence(tmp_path, monkeypatch):
+    file_path = make_video_file(tmp_path)
+    monkeypatch.setattr("src.estimation.get_history_index", lambda: FakeIndex(None))
+
+    estimate = estimate_fresh_file_time(str(file_path), grouped_percentiles={("h264", "1080p"): STATS_10})
+    assert estimate.confidence == "none"
+    assert estimate.source == "no_fresh_record"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tree_display.py
+++ b/tests/test_tree_display.py
@@ -1,8 +1,17 @@
 # tests/test_tree_display.py
-"""Tests for queue file status formatting and skip reason persistence."""
+"""Tests for tree display helpers in src/gui/tree_display.py.
 
-from src.gui.tree_display import format_queue_file_status
-from src.models import QueueFileItem, QueueItem, QueueItemStatus
+Covers queue file status formatting (including skip reason persistence) and
+compute_analysis_display_values. The latter is exercised with explicit
+FileRecord instances and pre-computed percentiles so the history index is
+never touched. Key contract (issue #6): the time estimate depends only on
+codec/duration/resolution and must not be suppressed when the savings
+estimate is unavailable.
+"""
+
+from src.gui.tree_display import compute_analysis_display_values, format_queue_file_status
+from src.models import FileRecord, FileStatus, QueueFileItem, QueueItem, QueueItemStatus
+from src.utils import format_file_size
 
 # ---------------------------------------------------------------------------
 # format_queue_file_status
@@ -68,3 +77,102 @@ def test_missing_skip_reason_key_defaults_to_none():
     restored = QueueItem.from_dict(data)
 
     assert restored.files[0].skip_reason is None
+
+
+# ---------------------------------------------------------------------------
+# compute_analysis_display_values
+# ---------------------------------------------------------------------------
+
+# duration 600s * p50 2.0 = 1200s = 20m; count 10 => high confidence (no prefix)
+PERCENTILES = {("h264", "1080p"): {"p25": 1.0, "p50": 2.0, "p75": 3.0, "count": 10}}
+
+ONE_GB = 1_073_741_824
+
+
+def make_record(**overrides) -> FileRecord:
+    defaults = {
+        "path_hash": "a" * 32,
+        "original_path": None,
+        "status": FileStatus.SCANNED,
+        "file_size_bytes": ONE_GB,
+        "file_mtime": 0.0,
+        "duration_sec": 600.0,
+        "video_codec": "h264",
+        "width": 1920,
+        "height": 1080,
+        "estimated_reduction_percent": 50.0,
+    }
+    defaults.update(overrides)
+    return FileRecord(**defaults)
+
+
+def test_scanned_record_shows_savings_time_and_efficiency():
+    record = make_record()
+    _, size_str, savings_str, time_str, eff_str, tag = compute_analysis_display_values(
+        record, grouped_percentiles=PERCENTILES
+    )
+    assert size_str == format_file_size(ONE_GB)
+    assert savings_str == f"~{format_file_size(ONE_GB // 2)}"  # Layer 1 => "~" prefix
+    assert time_str == "20m"
+    assert eff_str == "1.5 GB/h"  # 0.5 GB saved in 20 minutes
+    assert tag == ""
+
+
+def test_time_shown_without_reduction_estimate():
+    # Issue #6 regression: a record without a savings estimate (e.g., an alias
+    # record) must still show a time estimate - time needs only duration/codec.
+    record = make_record(estimated_reduction_percent=None)
+    _, _, savings_str, time_str, eff_str, _ = compute_analysis_display_values(record, grouped_percentiles=PERCENTILES)
+    assert savings_str == "—"
+    assert time_str == "20m"
+    assert eff_str == "—"
+
+
+def test_time_shown_without_file_size():
+    record = make_record(file_size_bytes=0)
+    _, size_str, savings_str, time_str, _, _ = compute_analysis_display_values(record, grouped_percentiles=PERCENTILES)
+    assert size_str == "—"
+    assert savings_str == "—"
+    assert time_str == "20m"
+
+
+def test_analyzed_record_uses_precise_prediction():
+    record = make_record(status=FileStatus.ANALYZED, predicted_size_reduction=25.0, estimated_reduction_percent=50.0)
+    _, _, savings_str, time_str, _, _ = compute_analysis_display_values(record, grouped_percentiles=PERCENTILES)
+    # Layer 2 prediction wins over the Layer 1 estimate and drops the "~" prefix
+    assert savings_str == format_file_size(ONE_GB // 4)
+    assert time_str == "20m"
+
+
+def test_no_duration_shows_no_time_but_keeps_savings():
+    record = make_record(duration_sec=None)
+    _, _, savings_str, time_str, eff_str, _ = compute_analysis_display_values(record, grouped_percentiles=PERCENTILES)
+    assert savings_str == f"~{format_file_size(ONE_GB // 2)}"
+    assert time_str == "—"
+    assert eff_str == "—"
+
+
+def test_no_percentile_data_shows_no_time():
+    record = make_record()
+    _, _, savings_str, time_str, eff_str, _ = compute_analysis_display_values(record, grouped_percentiles={})
+    assert savings_str == f"~{format_file_size(ONE_GB // 2)}"
+    assert time_str == "—"
+    assert eff_str == "—"
+
+
+def test_terminal_statuses_show_verdict_not_estimates():
+    converted = make_record(status=FileStatus.CONVERTED)
+    _, _, savings_str, time_str, _, tag = compute_analysis_display_values(converted, grouped_percentiles=PERCENTILES)
+    assert (savings_str, time_str, tag) == ("Done", "—", "done")
+
+    not_worthwhile = make_record(status=FileStatus.NOT_WORTHWHILE)
+    _, _, savings_str, time_str, _, tag = compute_analysis_display_values(
+        not_worthwhile, grouped_percentiles=PERCENTILES
+    )
+    assert (savings_str, time_str, tag) == ("Skip", "—", "skip")
+
+
+def test_av1_file_shows_av1_indicator():
+    record = make_record(video_codec="av1")
+    _, _, savings_str, time_str, _, tag = compute_analysis_display_values(record, grouped_percentiles=PERCENTILES)
+    assert (savings_str, time_str, tag) == ("AV1", "—", "av1")


### PR DESCRIPTION
A file could show "—" for its time estimate in the Analysis tab while the Queue tab showed an estimate for the same file (or vice versa), because each tab applied its own display rule. Both tabs now follow one rule: a time estimate is shown when a history record exists, still matches the file on disk (size + mtime), and has a duration.

Two defects caused the divergence:

- `compute_analysis_display_values` (and the folder aggregate/total paths) only computed the time and efficiency columns inside the savings branch, so a record without a reduction estimate or file size (e.g., alias records from duplicate detection) lost its time estimate even though time needs only codec/duration/resolution. The time computation is now independent of the savings inputs.
- The Queue tab used whatever history record existed, stale or not, while the Analysis tab requires the record's size and mtime to match the file on disk. Queue estimates now go through a new `estimate_fresh_file_time` helper in `src/estimation.py` that applies the same freshness check, which also collapses the queue's separate record/path estimate branches into one call.

One behavior consequence worth noting: folder aggregate rows in the Analysis tab now include time from files that lack a savings estimate, and such files count as convertible in the totals row. The worker's ETA path (`estimate_pending_files_eta`) intentionally keeps the old no-stat lookup since it runs on a timer.

Known cost: the freshness check adds one `os.stat` per file per queue tree refresh, and refreshes recompute the whole queue. Acceptable on local disks; on large network-drive queues it can hitch the UI on events like reorders or operation changes. #31 tracks the zero-I/O follow-up (snapshot size+mtime at add time).

Regression coverage: new `tests/test_tree_display.py` pins the time-without-savings cases for `compute_analysis_display_values`, and `tests/test_estimation.py` gains fresh/stale/missing-record tests for `estimate_fresh_file_time`.

Fixes #6
