### PR TITLE
ref(ab-av1): Consolidate subprocess management and cancellation into a runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,9 @@ src/
 ├── video_metadata.py          # Video metadata extraction from ffprobe
 ├── vendor_manager.py          # ab-av1/FFmpeg download and update management
 ├── ab_av1/                    # ab-av1 wrapper package
-│   ├── wrapper.py             # Subprocess management, VMAF fallback
+│   ├── wrapper.py             # High-level encode/crf-search orchestration, VMAF fallback
+│   ├── runner.py              # Subprocess lifecycle: spawn, stream output, cancel, reap
+│   ├── stats.py               # EncodeStats / CrfSearchResult dataclasses
 │   ├── parser.py              # Regex parsing of ab-av1/ffmpeg output
 │   ├── exceptions.py          # Custom exception hierarchy
 │   ├── checker.py             # ab-av1 availability check
@@ -233,7 +235,7 @@ When refactoring:
 ### Conventions
 - **Thread safety**: Never update GUI from worker thread directly. Use `update_ui_safely()`. The worker uses a single-writer model: `queue_item.*` is mutated directly by the one worker thread (UI only reads), `gui.session.*` is mutated via `update_ui_safely` (main thread). See `worker.py:34-44` for details. This is safe—don't add locks.
 - **Callbacks**: Events dispatch via `handle_*` functions in `gui/callback_handlers.py`.
-- **Exceptions**: Custom hierarchy in `ab_av1/exceptions.py` (InputFileError, OutputFileError, VMAFError, etc.)
+- **Exceptions**: Custom hierarchy in `ab_av1/exceptions.py` (InputFileError, OutputFileError, AbAv1CancelledError, ConversionNotWorthwhileError)
 - **Persistence**: JSON with atomic writes using `os.replace()`.
 - **Process management**: Track PID for graceful/force stop. Use `taskkill /T` on Windows.
 - **Error handling**: `except Exception:` + `logger.exception()` is correct for non-critical ops (UI updates, cache writes, metadata extraction). Conversions can run for hours—never abort due to a progress bar glitch. Log everything, continue with safe fallbacks.
@@ -255,7 +257,7 @@ ab-av1 output has two phases with different formats:
 - **Quality Detection**: Structured ab-av1 output, reliable progress
 - **Encoding**: FFmpeg output, subject to buffering, multiple regex patterns needed
 
-See `ab_av1/wrapper.py` for environment variables that maximize verbosity.
+`RUST_LOG` (set in `ab_av1/wrapper.py`) is the only environment variable ab-av1 reads. Encode operations use `debug,ab_av1=trace,ffmpeg=trace` (ffmpeg trace is needed to parse encoding progress); crf-search uses `debug,ab_av1=trace` (ffmpeg trace would just flood the sample runs).
 
 ## Data Files
 

--- a/docs/AB_AV1_PARSING.md
+++ b/docs/AB_AV1_PARSING.md
@@ -154,4 +154,4 @@ FFmpeg's progress output is subject to buffering, which can cause:
 - Multiple progress lines arriving at once
 - Gaps in progress reporting
 
-The environment variables in `wrapper.py` attempt to minimize buffering, but it's not fully controllable.
+Line-buffered pipe reads (`bufsize=1` in `runner.py`) minimize the effect, but FFmpeg's own buffering is not fully controllable.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -315,15 +315,15 @@ process = subprocess.Popen(
 ```
 
 ### Environment Variables
-Set for maximum output verbosity:
-- `RUST_LOG=trace,ab_av1=trace,ffmpeg=trace`
-- `AV1_PRINT_FFMPEG=1`
-- `SVT_VERBOSE=1`
+`RUST_LOG` (the only variable ab-av1 reads):
+- Encode operations: `debug,ab_av1=trace,ffmpeg=trace` (ffmpeg trace needed for encoding progress)
+- crf-search: `debug,ab_av1=trace` (ffmpeg trace would flood the sample runs)
 
 ### Process Termination
-- **Graceful stop**: Set `stop_event`, wait for current file to finish
-- **Force stop**: `taskkill /T /F /PID` (Windows) or `SIGKILL` (Unix)
+- **Graceful stop**: Set `stop_event`, wait for current file to finish (CONVERT); aborts mid-run for ANALYZE
+- **Force stop**: Sets `cancel_event` (the runner's read loop terminates and reaps the process tree), with `taskkill /T /F /PID` (Windows) or SIGTERM/SIGKILL (Unix) on the tracked PID as backstop
 - PID tracked via `pid_callback` mechanism
+- Hung-silent processes are terminated after `AB_AV1_SILENCE_TIMEOUT_SEC` (see `ab_av1/runner.py`)
 
 ## Output Parsing
 

--- a/src/ab_av1/exceptions.py
+++ b/src/ab_av1/exceptions.py
@@ -23,12 +23,8 @@ class OutputFileError(AbAv1Error):
     pass
 
 
-class VMAFError(AbAv1Error):
-    pass
-
-
-class EncodingError(AbAv1Error):
-    pass
+class AbAv1CancelledError(AbAv1Error):
+    """Exception raised when a run is cancelled via a cancel/stop event."""
 
 
 class ConversionNotWorthwhileError(AbAv1Error):

--- a/src/ab_av1/parser.py
+++ b/src/ab_av1/parser.py
@@ -15,6 +15,8 @@ from src.models import ProgressEvent
 from src.privacy import anonymize_filename
 from src.utils import format_crf
 
+from .stats import EncodeStats
+
 logger = logging.getLogger(__name__)
 
 
@@ -73,12 +75,12 @@ class AbAv1Parser:
         self._re_final_crf = re.compile(r"Best\s+CRF:\s+(\d+\.?\d*)", re.IGNORECASE)
 
     def _build_encoding_callback_data(
-        self, stats: dict[str, Any], progress_encoding: float, message: str, eta_text: str | None = None
+        self, stats: EncodeStats, progress_encoding: float, message: str, eta_text: str | None = None
     ) -> ProgressEvent:
         """Build ProgressEvent for encoding progress updates.
 
         Args:
-            stats: Current stats dictionary with vmaf, crf, size_reduction, etc.
+            stats: Current parse state with vmaf, crf, size_reduction, etc.
             progress_encoding: Current encoding progress percentage (0-100).
             message: Human-readable progress message.
             eta_text: Optional ETA text to include.
@@ -91,54 +93,48 @@ class AbAv1Parser:
             progress_encoding=progress_encoding,
             message=message,
             phase="encoding",
-            original_size=stats.get("original_size"),
-            vmaf=stats.get("vmaf"),
-            crf=stats.get("crf"),
-            size_reduction=stats.get("size_reduction"),
-            vmaf_target_used=stats.get("vmaf_target_used"),
+            original_size=stats.original_size,
+            vmaf=stats.vmaf,
+            crf=stats.crf,
+            size_reduction=stats.size_reduction,
+            vmaf_target_used=stats.vmaf_target_used,
             eta_text=eta_text,
-            output_size=stats.get("estimated_output_size") if stats.get("estimated_output_size") else None,
-            is_estimate=True if stats.get("estimated_output_size") else None,
         )
 
-    def parse_line(self, line: str, stats: dict) -> dict:
+    def parse_line(self, line: str, stats: EncodeStats) -> EncodeStats:
         """
         Parses a single line of output known to come from ab-av1's stdout/stderr,
-        updates the stats dictionary, and potentially triggers the file_info_callback.
+        updates the stats state, and potentially triggers the file_info_callback.
 
         Args:
             line: The line of text from stdout/stderr.
-            stats: The current statistics dictionary for the ongoing process.
+            stats: The current statistics state for the ongoing process.
 
         Returns:
-            The updated statistics dictionary.
+            The updated statistics state.
         """
         line = line.strip()
         if not line:
             return stats  # Skip empty lines
 
         try:
-            input_basename = os.path.basename(stats.get("input_path", "unknown_file"))
-            current_phase = stats.get("phase", "crf-search")
+            input_basename = os.path.basename(stats.input_path or "unknown_file")
+            current_phase = stats.phase
             processed_line = False  # Flag if line yielded useful info
 
             # --- Phase Transition Detection ---
             if current_phase == "crf-search" and self._re_phase_encode_start.search(line):
-                logger.info(
-                    f"Phase transition to Encoding detected for {anonymize_filename(stats.get('input_path', ''))}"
-                )
-                stats["phase"] = "encoding"
-                stats["progress_quality"] = 100.0
-                stats["progress_encoding"] = 0.0
-                stats["last_reported_encoding_progress"] = 0.0
+                logger.info(f"Phase transition to Encoding detected for {anonymize_filename(stats.input_path)}")
+                stats.phase = "encoding"
+                stats.progress_quality = 100.0
+                stats.progress_encoding = 0.0
                 processed_line = True
 
                 # Log extra information about this transition
                 logger.info(
-                    f"Starting encoding phase with CRF: {format_crf(stats.get('crf'))}, "
-                    f"VMAF Target: {stats.get('vmaf_target_used', '?')}"
+                    f"Starting encoding phase with CRF: {format_crf(stats.crf)}, VMAF Target: {stats.vmaf_target_used}"
                 )
-                logger.info(f"Duration in seconds: {stats.get('total_duration_seconds', '?')}")
+                logger.info(f"Duration in seconds: {stats.total_duration_seconds}")
                 logger.info("Looking for ffmpeg progress output lines in the form 'frame=XXX fps=XXX time=XX:XX:XX'")
 
                 if self.file_info_callback:
@@ -146,29 +142,29 @@ class AbAv1Parser:
                         progress_quality=100.0,
                         progress_encoding=0.0,
                         message="Encoding started",
-                        phase=stats["phase"],
-                        vmaf=stats.get("vmaf"),
-                        crf=stats.get("crf"),
-                        size_reduction=stats.get("size_reduction"),  # Use predicted if available
-                        original_size=stats.get("original_size"),
-                        vmaf_target_used=stats.get("vmaf_target_used"),
+                        phase=stats.phase,
+                        vmaf=stats.vmaf,
+                        crf=stats.crf,
+                        size_reduction=stats.size_reduction,  # Use predicted if available
+                        original_size=stats.original_size,
+                        vmaf_target_used=stats.vmaf_target_used,
                     )
                     self.file_info_callback(input_basename, "progress", callback_info)
                 return stats  # Return early
 
             # --- CRF Search Phase Parsing ---
             if current_phase == "crf-search":
-                new_quality_progress = stats.get("progress_quality", 0)
+                new_quality_progress = stats.progress_quality
                 crf_vmaf_match = self._re_crf_vmaf.search(line)
                 if crf_vmaf_match:
                     processed_line = True
                     try:
                         crf_val = float(crf_vmaf_match.group(1))
                         vmaf_val = float(crf_vmaf_match.group(2))
-                        stats["crf"] = crf_val
-                        stats["vmaf"] = vmaf_val
-                        logger.info(f"CRF search update: CRF={format_crf(stats['crf'])}, VMAF={stats['vmaf']:.2f}")
-                        new_quality_progress = min(90.0, stats.get("progress_quality", 0) + 10.0)
+                        stats.crf = crf_val
+                        stats.vmaf = vmaf_val
+                        logger.info(f"CRF search update: CRF={format_crf(stats.crf)}, VMAF={stats.vmaf:.2f}")
+                        new_quality_progress = min(90.0, stats.progress_quality + 10.0)
                     except (ValueError, IndexError) as e:
                         logger.warning(f"Error parsing CRF/VMAF values from line '{line[:80]}...': {e}")
 
@@ -177,8 +173,8 @@ class AbAv1Parser:
                     processed_line = True
                     try:
                         crf_val = float(best_crf_match.group(1))
-                        stats["crf"] = crf_val
-                        logger.info(f"Best CRF determined: {format_crf(stats['crf'])}")
+                        stats.crf = crf_val
+                        logger.info(f"Best CRF determined: {format_crf(stats.crf)}")
                         new_quality_progress = 95.0
                     except (ValueError, IndexError) as e:
                         logger.warning(f"Error parsing Best CRF value from line '{line[:80]}...': {e}")
@@ -192,40 +188,38 @@ class AbAv1Parser:
                         # This is percentage *of original*, so reduction is 100 - this
                         new_size_reduction = 100.0 - size_percentage
                         # Only update if changed significantly
-                        # Using None check to prevent TypeError: unsupported operand type(s)
-                        # for -: 'NoneType' and 'float'
-                        current_reduction = stats.get("size_reduction")
+                        # (None check prevents TypeError on the first update)
+                        current_reduction = stats.size_reduction
                         reduction_changed = (
                             current_reduction is None
                             or abs(current_reduction - new_size_reduction) > SIZE_REDUCTION_CHANGE_THRESHOLD
                         )
                         if reduction_changed:
-                            stats["size_reduction"] = new_size_reduction
-                            logger.info(f"Parsed predicted size reduction: {stats['size_reduction']:.1f}%")
+                            stats.size_reduction = new_size_reduction
+                            logger.info(f"Parsed predicted size reduction: {stats.size_reduction:.1f}%")
                     except (ValueError, IndexError) as e:
                         logger.warning(f"Cannot parse predicted size reduction % from line '{line[:80]}...': {e}")
 
                 # Send callback if quality progress increased
-                if new_quality_progress > stats.get("progress_quality", 0):
-                    stats["progress_quality"] = new_quality_progress
+                if new_quality_progress > stats.progress_quality:
+                    stats.progress_quality = new_quality_progress
                     if self.file_info_callback:
                         vmaf_part = "?"
-                        current_vmaf = stats.get("vmaf")
-                        if current_vmaf is not None:
+                        if stats.vmaf is not None:
                             try:
-                                vmaf_part = f"{float(current_vmaf):.1f}"
+                                vmaf_part = f"{float(stats.vmaf):.1f}"
                             except (ValueError, TypeError):
-                                vmaf_part = str(current_vmaf)
+                                vmaf_part = str(stats.vmaf)
                         callback_info = ProgressEvent(
-                            progress_quality=stats["progress_quality"],
+                            progress_quality=stats.progress_quality,
                             progress_encoding=0,
-                            message=f"Detecting Quality (CRF:{format_crf(stats.get('crf'))}, VMAF:{vmaf_part})",
+                            message=f"Detecting Quality (CRF:{format_crf(stats.crf)}, VMAF:{vmaf_part})",
                             phase=current_phase,
-                            vmaf=stats.get("vmaf"),
-                            crf=stats.get("crf"),
-                            size_reduction=stats.get("size_reduction"),  # Include prediction
-                            original_size=stats.get("original_size"),
-                            vmaf_target_used=stats.get("vmaf_target_used"),
+                            vmaf=stats.vmaf,
+                            crf=stats.crf,
+                            size_reduction=stats.size_reduction,  # Include prediction
+                            original_size=stats.original_size,
+                            vmaf_target_used=stats.vmaf_target_used,
                         )
                         self.file_info_callback(input_basename, "progress", callback_info)
 
@@ -241,9 +235,9 @@ class AbAv1Parser:
                     logger.info(f"Sample encoding progress detected: {progress_pct}%, {fps} fps, ETA: {eta_text}")
 
                     # Update stats
-                    stats["progress_encoding"] = progress_pct
-                    stats["last_ffmpeg_fps"] = fps
-                    stats["eta_text"] = eta_text
+                    stats.progress_encoding = progress_pct
+                    stats.last_ffmpeg_fps = fps
+                    stats.eta_text = eta_text
 
                     # Send progress update
                     if self.file_info_callback:
@@ -266,9 +260,9 @@ class AbAv1Parser:
                     logger.info(f"Main encoding progress: {progress_pct}%, {fps} fps, ETA: {eta_text}")
 
                     # Update stats
-                    stats["progress_encoding"] = progress_pct
-                    stats["last_ffmpeg_fps"] = fps
-                    stats["eta_text"] = eta_text
+                    stats.progress_encoding = progress_pct
+                    stats.last_ffmpeg_fps = fps
+                    stats.eta_text = eta_text
 
                     # Send progress update
                     if self.file_info_callback:
@@ -282,13 +276,13 @@ class AbAv1Parser:
                 # Parse raw ffmpeg progress output (time=HH:MM:SS.ss format)
                 # This is more frequent than ab-av1's summary lines for large files
                 ffmpeg_time_match = self._re_ffmpeg_time.search(line)
-                if ffmpeg_time_match and stats.get("total_duration_seconds"):
+                if ffmpeg_time_match and stats.total_duration_seconds:
                     try:
                         hours = int(ffmpeg_time_match.group(1))
                         minutes = int(ffmpeg_time_match.group(2))
                         seconds = float(ffmpeg_time_match.group(3))
                         current_seconds = hours * 3600 + minutes * 60 + seconds
-                        total_seconds = stats["total_duration_seconds"]
+                        total_seconds = stats.total_duration_seconds
 
                         if total_seconds > 0:
                             progress_pct = min(99.9, (current_seconds / total_seconds) * 100)
@@ -299,15 +293,15 @@ class AbAv1Parser:
                             fps_match = self._re_ffmpeg_fps.search(line)
                             if fps_match:
                                 fps = float(fps_match.group(1))
-                                stats["last_ffmpeg_fps"] = fps
+                                stats.last_ffmpeg_fps = fps
                             speed_match = self._re_ffmpeg_speed.search(line)
                             if speed_match:
                                 speed = float(speed_match.group(1))
 
                             # Only update if progress increased by at least 0.1%
-                            last_progress = stats.get("progress_encoding", 0.0)
+                            last_progress = stats.progress_encoding
                             if progress_pct >= last_progress + 0.1:
-                                stats["progress_encoding"] = progress_pct
+                                stats.progress_encoding = progress_pct
 
                                 # Build message
                                 if fps and speed:
@@ -334,12 +328,12 @@ class AbAv1Parser:
                     # Only update if progress increased by at least 0.1% (same guard as the
                     # ffmpeg time= path): a stray low percentage in unrelated output must
                     # never drag the progress bar backwards
-                    last_progress = stats.get("progress_encoding", 0.0)
+                    last_progress = stats.progress_encoding
                     if progress_pct >= last_progress + 0.1:
                         logger.info(f"Percentage detected in line: {progress_pct}% in '{line}'")
 
                         # Basic progress update (no FPS or ETA)
-                        stats["progress_encoding"] = progress_pct
+                        stats.progress_encoding = progress_pct
 
                         # Send progress update
                         if self.file_info_callback:
@@ -357,13 +351,13 @@ class AbAv1Parser:
                         phase_text = summary_match.group(2)
                         eta_text = summary_match.group(3).strip()
                         # Only update ETA if it changed to avoid spamming logs/UI
-                        if stats.get("eta_text") != eta_text:
-                            stats["eta_text"] = eta_text
+                        if stats.eta_text != eta_text:
+                            stats.eta_text = eta_text
                             logger.info(f"Parsed ab-av1 summary: Phase='{phase_text}', ETA='{eta_text}'")
 
                             # Send progress update using existing percentage, new ETA
                             if self.file_info_callback:
-                                current_progress = stats.get("progress_encoding", 0.0)
+                                current_progress = stats.progress_encoding
                                 message = f"Encoding: {current_progress:.1f}% (ETA: {eta_text})"
                                 callback_data = self._build_encoding_callback_data(
                                     stats, current_progress, message, eta_text
@@ -384,28 +378,28 @@ class AbAv1Parser:
             if processed_line:
                 # Log key stats that are expected to be updated by this parser
                 logger.debug(
-                    f"Post-Parse Stats: Phase={stats.get('phase')}, "
-                    f"Qual={stats.get('progress_quality', 0):.1f}%, VMAF={stats.get('vmaf')}, "
-                    f"CRF={format_crf(stats.get('crf'))}, ETA={stats.get('eta_text')}, "
-                    f"SizeReduc={stats.get('size_reduction')}"
+                    f"Post-Parse Stats: Phase={stats.phase}, "
+                    f"Qual={stats.progress_quality:.1f}%, VMAF={stats.vmaf}, "
+                    f"CRF={format_crf(stats.crf)}, ETA={stats.eta_text}, "
+                    f"SizeReduc={stats.size_reduction}"
                 )
 
         except Exception:
             logger.exception(f"General error processing output line: '{line[:80]}...'")
 
-        return stats  # Always return the potentially modified stats dictionary
+        return stats  # Always return the potentially modified stats state
 
-    def parse_final_output(self, output_text: str, stats: dict) -> dict:
+    def parse_final_output(self, output_text: str, stats: EncodeStats) -> EncodeStats:
         """
         Extract final statistics from the complete output text (main pipe) as a fallback
-        or verification step, updating the provided stats dictionary.
+        or verification step, updating the provided stats state.
 
         Args:
             output_text: The complete console output text from ab-av1's stdout/stderr.
-            stats: The statistics dictionary to update.
+            stats: The statistics state to update.
 
         Returns:
-            The updated statistics dictionary.
+            The updated statistics state.
         """
         logger.debug("Running final output parsing on main pipe text as fallback/verification.")
 
@@ -414,10 +408,10 @@ class AbAv1Parser:
             vmaf_matches = self._re_final_vmaf.findall(output_text)
             if vmaf_matches:
                 final_vmaf = float(vmaf_matches[-1])
-                if stats.get("vmaf") is None or abs(stats.get("vmaf", -1.0) - final_vmaf) > VMAF_CHANGE_THRESHOLD:
-                    logger.info(f"[Final Parse] VMAF verified/updated: {final_vmaf:.2f} (from {stats.get('vmaf')})")
-                    stats["vmaf"] = final_vmaf
-            elif stats.get("vmaf") is None:
+                if stats.vmaf is None or abs(stats.vmaf - final_vmaf) > VMAF_CHANGE_THRESHOLD:
+                    logger.info(f"[Final Parse] VMAF verified/updated: {final_vmaf:.2f} (from {stats.vmaf})")
+                    stats.vmaf = final_vmaf
+            elif stats.vmaf is None:
                 logger.warning("[Final Parse] Could not find VMAF score in main pipe output.")
         except (ValueError, IndexError, TypeError) as e:
             logger.warning(f"[Final Parse] Error parsing final VMAF score: {e}")
@@ -427,20 +421,18 @@ class AbAv1Parser:
             crf_matches = self._re_final_crf.findall(output_text)
             if crf_matches:
                 final_crf = float(crf_matches[-1])
-                if stats.get("crf") != final_crf:
-                    logger.info(
-                        f"[Final Parse] CRF verified/updated: {format_crf(final_crf)} (from {stats.get('crf')})"
-                    )
-                    stats["crf"] = final_crf
-            elif stats.get("crf") is None:
+                if stats.crf != final_crf:
+                    logger.info(f"[Final Parse] CRF verified/updated: {format_crf(final_crf)} (from {stats.crf})")
+                    stats.crf = final_crf
+            elif stats.crf is None:
                 logger.warning("[Final Parse] Could not find Best CRF in main pipe output.")
         except (ValueError, IndexError, TypeError) as e:
             logger.warning(f"[Final Parse] Error parsing final CRF score: {e}")
 
         # --- Final Size Reduction ---
         # Use the value potentially parsed earlier from predicted size line
-        if stats.get("size_reduction") is not None:
-            logger.info(f"[Final Parse] Using previously parsed size reduction: {stats['size_reduction']:.2f}%")
+        if stats.size_reduction is not None:
+            logger.info(f"[Final Parse] Using previously parsed size reduction: {stats.size_reduction:.2f}%")
         else:
             # Try parsing the predicted size line again from the full text as a last resort
             size_match = self._re_size_reduction_percent.search(output_text)
@@ -448,9 +440,9 @@ class AbAv1Parser:
                 try:
                     size_percentage = float(size_match.group(1))
                     final_size_reduction = 100.0 - size_percentage
-                    stats["size_reduction"] = final_size_reduction
+                    stats.size_reduction = final_size_reduction
                     logger.info(
-                        f"[Final Parse] Found predicted size reduction in final text: {stats['size_reduction']:.1f}%"
+                        f"[Final Parse] Found predicted size reduction in final text: {stats.size_reduction:.1f}%"
                     )
                 except (ValueError, IndexError) as e:
                     logger.warning(f"[Final Parse] Cannot parse final predicted size reduction %: {e}")

--- a/src/ab_av1/runner.py
+++ b/src/ab_av1/runner.py
@@ -1,0 +1,228 @@
+# src/ab_av1/runner.py
+"""
+Subprocess lifecycle for ab-av1: spawn, stream output, cancel, and reap.
+
+A dedicated reader thread feeds lines into a queue so the main loop can wake
+on a poll interval even while the process is silent - this is what makes
+cancellation and hang detection work between output lines. The runner is
+parser-agnostic: callers observe output through the ``on_line`` callback.
+"""
+
+import logging
+import queue
+import subprocess
+import sys
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from src.config import (
+    AB_AV1_EOF_WAIT_SEC,
+    AB_AV1_OUTPUT_POLL_SEC,
+    AB_AV1_SILENCE_TIMEOUT_SEC,
+    AB_AV1_TERMINATE_WAIT_SEC,
+)
+from src.platform_utils import get_windows_subprocess_startupinfo, terminate_process_tree
+
+logger = logging.getLogger(__name__)
+
+# Sentinel the reader thread enqueues when the process closes its output pipe
+_EOF = object()
+
+# ab-av1's main.rs prints "Error: {err}" to stderr as its final act before exit(1).
+# stderr is merged into stdout, so the failure reason is the last such line.
+_ERROR_PREFIX = "Error: "
+
+
+@dataclass
+class ProcessResult:
+    """Outcome of one ab-av1 process run."""
+
+    return_code: int
+    output: str  # merged stdout+stderr, noise-filtered, newline-joined
+    error_line: str | None  # on failure, text after the LAST line starting with "Error: "; else None
+    cancelled: bool = False
+    silence_timeout: bool = False
+
+
+def _extract_error_line(lines: list[str]) -> str | None:
+    """Return the message of the last "Error: ..." line, or None."""
+    for line in reversed(lines):
+        if line.startswith(_ERROR_PREFIX):
+            return line[len(_ERROR_PREFIX) :]
+    return None
+
+
+def _terminate_and_reap(process: Any, terminate_wait_sec: float) -> int:
+    """Kill the process tree, wait until the child is reaped (escalating if needed).
+
+    Returns:
+        The process's exit code, or -1 if it could not be reaped.
+    """
+    terminate_process_tree(process.pid)
+    try:
+        process.wait(timeout=terminate_wait_sec)
+    except subprocess.TimeoutExpired:
+        logger.warning(f"Process {process.pid} still alive after tree kill; escalating to kill()")
+        process.kill()
+        try:
+            process.wait(timeout=terminate_wait_sec)
+        except subprocess.TimeoutExpired:
+            logger.exception(f"Process {process.pid} could not be reaped after kill()")
+    rc = process.poll()
+    return rc if rc is not None else -1
+
+
+def run_ab_av1(
+    cmd: list[str],
+    *,
+    cwd: str,
+    env: dict[str, str],
+    on_line: Callable[[str], None] | None = None,
+    cancel_event: Any | None = None,
+    pid_callback: Callable[[int], None] | None = None,
+    silence_timeout_sec: float = AB_AV1_SILENCE_TIMEOUT_SEC,
+    poll_interval_sec: float = AB_AV1_OUTPUT_POLL_SEC,
+    eof_wait_sec: float = AB_AV1_EOF_WAIT_SEC,
+    terminate_wait_sec: float = AB_AV1_TERMINATE_WAIT_SEC,
+) -> ProcessResult:
+    """Run an ab-av1 command to completion, cancellation, or hang timeout.
+
+    Args:
+        cmd: Full command line (executable + args).
+        cwd: Working directory for the process (where temp folders appear).
+        env: Environment for the process.
+        on_line: Called for each non-noise output line. Exceptions are logged
+            and swallowed - a callback bug must never kill an hours-long encode.
+        cancel_event: Event checked between lines and on every poll interval;
+            when set, the process tree is terminated and ``cancelled`` is True.
+        pid_callback: Called with the process PID right after spawn.
+        silence_timeout_sec: No output for this long terminates the process
+            and sets ``silence_timeout`` (RUST_LOG debug output makes a healthy
+            run chatty, so prolonged silence means a hung process).
+        poll_interval_sec: Wake interval for cancel/silence checks.
+        eof_wait_sec: How long to wait for exit after the pipe closes.
+        terminate_wait_sec: Reap wait after terminate/kill before escalating.
+
+    Returns:
+        ProcessResult with the exit code, collected output, and flags.
+
+    Raises:
+        FileNotFoundError: If the executable cannot be spawned.
+    """
+    startupinfo, creationflags = get_windows_subprocess_startupinfo()
+    process = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True,
+        bufsize=1,
+        cwd=cwd,
+        startupinfo=startupinfo,
+        creationflags=creationflags,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+        # POSIX: make ab-av1 a session leader so terminate_process_tree can
+        # SIGKILL the whole group (a hung ffmpeg can't forward signals).
+        start_new_session=(sys.platform != "win32"),
+    )
+
+    if pid_callback:
+        try:
+            pid_callback(process.pid)
+        except Exception:
+            logger.exception("pid_callback failed")
+
+    logger.info(f"ab-av1 process {process.pid} started. Reading output...")
+
+    line_queue: queue.Queue = queue.Queue()
+    stdout_stream = process.stdout
+    assert stdout_stream is not None  # Guaranteed by stdout=PIPE  # noqa: S101
+
+    def _reader() -> None:
+        try:
+            for raw_line in iter(stdout_stream.readline, ""):
+                line_queue.put(raw_line)
+        except Exception:
+            logger.exception(f"Reader thread failed for process {process.pid}")
+        finally:
+            line_queue.put(_EOF)
+
+    reader = threading.Thread(target=_reader, name="ab-av1-reader", daemon=True)
+    reader.start()
+
+    lines: list[str] = []
+    cancelled = False
+    silence_timeout = False
+    last_output_time = time.monotonic()
+
+    while True:
+        try:
+            item = line_queue.get(timeout=poll_interval_sec)
+        except queue.Empty:
+            if cancel_event is not None and cancel_event.is_set():
+                cancelled = True
+                break
+            if time.monotonic() - last_output_time > silence_timeout_sec:
+                silence_timeout = True
+                break
+            continue
+
+        if item is _EOF:
+            break
+
+        last_output_time = time.monotonic()
+        line = item.strip()
+        if not line or "sled::pagecache" in line:
+            continue
+        lines.append(line)
+        if on_line is not None:
+            try:
+                on_line(line)
+            except Exception:
+                logger.exception(f"on_line callback failed for line: '{line[:80]}'")
+        if cancel_event is not None and cancel_event.is_set():
+            cancelled = True
+            break
+
+    if cancelled or silence_timeout:
+        reason = "cancelled" if cancelled else f"silent for over {silence_timeout_sec}s"
+        logger.warning(f"Terminating ab-av1 process {process.pid} ({reason})")
+        return_code = _terminate_and_reap(process, terminate_wait_sec)
+    else:
+        try:
+            return_code = process.wait(timeout=eof_wait_sec)
+        except subprocess.TimeoutExpired:
+            logger.warning(f"Process {process.pid} did not exit within {eof_wait_sec}s after closing its pipe")
+            return_code = _terminate_and_reap(process, terminate_wait_sec)
+
+    # An out-of-band kill (e.g. the GUI's force-stop backstop) can close the pipe
+    # before the poll loop sees cancel_event; latch cancellation so a user stop is
+    # never reported as a failure. A genuine rc=0 success still wins.
+    if not cancelled and return_code != 0 and cancel_event is not None and cancel_event.is_set():
+        logger.info(f"Process {process.pid} exited rc={return_code} with cancel_event set; treating as cancelled")
+        cancelled = True
+
+    # Only close the pipe once the reader is done with it: closing while the
+    # reader blocks in readline() would deadlock on the buffered-IO lock.
+    reader.join(timeout=terminate_wait_sec)
+    if reader.is_alive():
+        logger.warning(f"Reader thread for process {process.pid} still alive; leaving stdout pipe open")
+    else:
+        try:
+            if process.stdout:
+                process.stdout.close()
+        except Exception as e:
+            logger.warning(f"Error closing process stdout pipe: {e}")
+
+    logger.info(f"ab-av1 process {process.pid} finished with return code {return_code}")
+    return ProcessResult(
+        return_code=return_code,
+        output="\n".join(lines),
+        error_line=_extract_error_line(lines) if return_code != 0 else None,
+        cancelled=cancelled,
+        silence_timeout=silence_timeout,
+    )

--- a/src/ab_av1/stats.py
+++ b/src/ab_av1/stats.py
@@ -1,0 +1,64 @@
+# src/ab_av1/stats.py
+"""
+Result and live-state containers for ab-av1 runs.
+
+EncodeStats is the mutable parse state threaded through AbAv1Parser during a
+run; CrfSearchResult is the immutable outcome of a crf-search.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class EncodeStats:
+    """Live parse state and final statistics for an encode or crf-search run."""
+
+    input_path: str = ""
+    output_path: str = ""
+    command: str = ""
+    phase: str = "crf-search"  # "crf-search" | "encoding"
+    progress_quality: float = 0.0
+    progress_encoding: float = 0.0
+    vmaf: float | None = None
+    crf: float | None = None
+    size_reduction: float | None = None
+    original_size: int | None = None
+    output_size: int | None = None
+    vmaf_target_used: int | None = None
+    total_duration_seconds: float = 0.0
+    last_ffmpeg_fps: float | None = None
+    eta_text: str | None = None
+    used_cached_crf: bool = False
+    crf_search_time_sec: float = 0.0
+    encoding_time_sec: float = 0.0
+
+    def reset_for_attempt(self, vmaf_target: int) -> None:
+        """Reset per-attempt parse state before a VMAF fallback retry.
+
+        size_reduction is deliberately NOT reset: the prediction from an
+        earlier attempt remains the best available estimate until the next
+        attempt parses a new one.
+        """
+        self.phase = "crf-search"
+        self.progress_quality = 0.0
+        self.progress_encoding = 0.0
+        self.vmaf = None
+        self.crf = None
+        self.eta_text = None
+        self.last_ffmpeg_fps = None
+        self.vmaf_target_used = vmaf_target
+
+
+@dataclass
+class CrfSearchResult:
+    """Outcome of a successful crf-search (quality analysis without encoding)."""
+
+    best_crf: float
+    best_vmaf: float
+    predicted_size_reduction: float | None
+    predicted_output_size: int | None
+    vmaf_target_used: int
+    original_size: int | None
+    used_fallback: bool
+    preset_used: int
+    crf_search_time_sec: float

--- a/src/ab_av1/wrapper.py
+++ b/src/ab_av1/wrapper.py
@@ -2,23 +2,27 @@
 """
 Wrapper class for the ab-av1 tool in the AV1 Video Converter application.
 
-Handles executing ab-av1, managing the process, VMAF fallback,
-and coordinating with the parser for output analysis.
-Uses a simple blocking read loop for stdout/stderr.
-Uses RUST_LOG for detailed ffmpeg progress output.
+Provides the high-level operations (auto-encode, crf-search, encode) on top of
+runner.run_ab_av1, sharing input validation, environment setup, the VMAF
+fallback loop, and failure detection across all three.
+
+Failure detection relies on ab-av1's contract: it exits 0/1 only, and prints
+"Error: {err}" to stderr as its final line on failure (merged into stdout here).
 """
 
 import logging
 import os
-import re
-import subprocess
 import time
 from collections.abc import Callable
-from typing import Any
+from typing import Any, NoReturn
 
-# Project imports
-from src.config import DEFAULT_ENCODING_PRESET, DEFAULT_VMAF_TARGET, MIN_VMAF_FALLBACK_TARGET, VMAF_FALLBACK_STEP
-from src.platform_utils import get_windows_subprocess_startupinfo
+from src.config import (
+    AB_AV1_NO_SUITABLE_CRF_MESSAGE,
+    DEFAULT_ENCODING_PRESET,
+    DEFAULT_VMAF_TARGET,
+    MIN_VMAF_FALLBACK_TARGET,
+    VMAF_FALLBACK_STEP,
+)
 from src.privacy import anonymize_filename
 from src.utils import format_crf, format_file_size, get_video_info
 from src.vendor_manager import AB_AV1_EXE, AB_AV1_EXE_NAME, FFMPEG_DIR, get_ab_av1_path
@@ -26,19 +30,32 @@ from src.video_metadata import extract_video_metadata
 
 from .checker import get_log_interval_for_duration
 from .cleaner import clean_ab_av1_temp_folders
-
-# Import exceptions, cleaner, parser from this package
-from .exceptions import (
-    AbAv1Error,
-    ConversionNotWorthwhileError,
-    EncodingError,
-    InputFileError,
-    OutputFileError,
-    VMAFError,
-)
+from .exceptions import AbAv1CancelledError, AbAv1Error, ConversionNotWorthwhileError, InputFileError, OutputFileError
 from .parser import AbAv1Parser
+from .runner import ProcessResult, run_ab_av1
+from .stats import CrfSearchResult, EncodeStats
 
 logger = logging.getLogger(__name__)
+
+
+def _is_no_suitable_crf(result: ProcessResult) -> bool:
+    """True if a failed run means "no CRF meets the VMAF target" (fallback trigger).
+
+    Matched case-insensitively as a substring of the error line - falling back to
+    the full output if no "Error: " line was found - so wording drift in future
+    ab-av1 releases doesn't silently disable the VMAF fallback ladder.
+    """
+    haystack = result.error_line if result.error_line is not None else result.output
+    return AB_AV1_NO_SUITABLE_CRF_MESSAGE.lower() in haystack.lower()
+
+
+def _format_cmd_for_log(cmd: list[str], replacements: dict[str, str]) -> str:
+    """Build the anonymized log form of a command by mapping known tokens.
+
+    Deriving the log string from the real command (instead of maintaining a
+    parallel list) keeps the two from drifting apart.
+    """
+    return " ".join(replacements.get(token, token) for token in cmd)
 
 
 class AbAv1Wrapper:
@@ -63,6 +80,264 @@ class AbAv1Wrapper:
         self.parser = AbAv1Parser()
         self.file_info_callback = None
 
+    # --- Shared helpers ---
+
+    def _fail(self, input_path: str, message: str, error_type: str, **extra: Any) -> None:
+        """Emit a "failed" file_info_callback if one is set."""
+        if self.file_info_callback:
+            info = {"message": message, "type": error_type}
+            info.update(extra)
+            self.file_info_callback(os.path.basename(input_path), "failed", info)
+
+    def _validate_input(self, input_path: str) -> tuple[dict, int | None]:
+        """Check the input exists and is a video; return (video_info, size or None).
+
+        Raises:
+            InputFileError: If the input is missing, unreadable, or has no video stream.
+        """
+        anonymized = anonymize_filename(input_path)
+        if not os.path.exists(input_path):
+            error_msg = f"Input not found: {anonymized}"
+            logger.error(error_msg)
+            self._fail(input_path, error_msg, "missing_input")
+            raise InputFileError(error_msg, error_type="missing_input")
+
+        try:
+            video_info = get_video_info(input_path)
+            if not video_info or "streams" not in video_info:
+                raise InputFileError("Invalid video file", error_type="invalid_video")
+            if not extract_video_metadata(video_info).has_video:
+                raise InputFileError("No video stream", error_type="no_video_stream")
+        except InputFileError as e:
+            logger.error(f"{e.message} ({anonymized})")  # noqa: TRY400 - no traceback needed for expected validation failure
+            self._fail(input_path, e.message, e.error_type or "invalid_video")
+            raise
+        except Exception as e:
+            error_msg = f"Error analyzing {anonymized}"
+            logger.exception(error_msg)
+            self._fail(input_path, error_msg, "analysis_failed")
+            raise InputFileError(error_msg, error_type="analysis_failed") from e
+
+        try:
+            original_size = os.path.getsize(input_path)
+            logger.info(f"Original file size: {original_size} bytes ({format_file_size(original_size)})")
+        except Exception as size_e:
+            logger.warning(f"Couldn't get original file size: {size_e}")
+            original_size = None
+        return video_info, original_size
+
+    def _prepare_output(self, input_path: str, output_path: str) -> tuple[str, str]:
+        """Coerce the output to .mkv and create its directory; return (path, dir).
+
+        Raises:
+            OutputFileError: If the output directory cannot be created.
+        """
+        if not output_path.lower().endswith(".mkv"):
+            output_path = os.path.splitext(output_path)[0] + ".mkv"
+        output_dir = os.path.dirname(output_path)
+        try:
+            os.makedirs(output_dir, exist_ok=True)
+        except Exception as e:
+            error_msg = "Cannot create output dir"
+            logger.exception(error_msg)
+            self._fail(input_path, error_msg, "output_dir_creation_failed")
+            raise OutputFileError(error_msg, error_type="output_dir_creation_failed") from e
+        return output_path, output_dir
+
+    @staticmethod
+    def _process_env(verbose_ffmpeg: bool) -> dict[str, str]:
+        """Build the subprocess environment: vendor FFmpeg on PATH, verbose RUST_LOG.
+
+        verbose_ffmpeg adds per-frame ffmpeg trace output - needed to parse
+        encoding progress, but pure noise for crf-search sample runs.
+        """
+        env = os.environ.copy()
+        # If vendor FFmpeg exists, prepend it to PATH so ab-av1 finds it.
+        # This only affects this subprocess - user's system PATH is unchanged.
+        if FFMPEG_DIR.exists():
+            env["PATH"] = str(FFMPEG_DIR) + os.pathsep + env.get("PATH", "")
+            logger.debug(f"Using vendor FFmpeg from {FFMPEG_DIR}")
+        env["RUST_LOG"] = "debug,ab_av1=trace,ffmpeg=trace" if verbose_ffmpeg else "debug,ab_av1=trace"
+        return env
+
+    def _run_once(
+        self,
+        cmd: list[str],
+        *,
+        input_path: str,
+        cwd: str,
+        env: dict[str, str],
+        on_line: Callable[[str], None] | None,
+        cancel_event: Any | None,
+        pid_callback: Callable[..., Any] | None,
+    ) -> ProcessResult:
+        """Run one ab-av1 process, reporting spawn failures via callback.
+
+        Raises:
+            FileNotFoundError: If the executable is missing.
+            AbAv1Error: If the process cannot be spawned for any other OS reason
+                (e.g. corrupt or non-executable binary).
+        """
+        try:
+            return run_ab_av1(
+                cmd, cwd=cwd, env=env, on_line=on_line, cancel_event=cancel_event, pid_callback=pid_callback
+            )
+        except FileNotFoundError:
+            error_msg = f"Executable not found: {self.executable_path}"
+            logger.exception(error_msg)
+            self._fail(input_path, error_msg, "executable_not_found")
+            raise
+        except OSError as e:
+            error_msg = f"Failed to start ab-av1 process: {e}"
+            logger.exception(error_msg)
+            self._fail(input_path, error_msg, "process_spawn_failed")
+            raise AbAv1Error(error_msg, error_type="process_spawn_failed") from e
+
+    def _raise_for_failed_result(
+        self, result: ProcessResult, *, input_path: str, cmd_str_log: str, cleanup_dir: str, failure_error_type: str
+    ) -> NoReturn:
+        """Clean temp folders and raise for a cancelled / hung / failed run.
+
+        Raises:
+            AbAv1CancelledError: The run was cancelled via cancel_event.
+            AbAv1Error: Silence timeout, or any other failure (failure_error_type).
+        """
+        clean_ab_av1_temp_folders(cleanup_dir)
+
+        if result.cancelled:
+            logger.info(f"ab-av1 run cancelled for {anonymize_filename(input_path)}")
+            raise AbAv1CancelledError("Cancelled by user", command=cmd_str_log, error_type="cancelled")
+
+        if result.silence_timeout:
+            error_msg = f"ab-av1 produced no output for too long and was terminated (rc={result.return_code})"
+            logger.error(error_msg)
+            self._fail(input_path, error_msg, "process_silent_timeout")
+            raise AbAv1Error(error_msg, command=cmd_str_log, output=result.output, error_type="process_silent_timeout")
+
+        detail = result.error_line or f"exit code {result.return_code}"
+        error_msg = f"ab-av1 failed (rc={result.return_code}): {detail}"
+        logger.error(error_msg)
+        logger.error(f"Last Cmd: {cmd_str_log}")
+        tail = result.output.splitlines()[-20:] if result.output else ["<No output captured>"]
+        logger.error(f"Last Output tail ({len(tail)} lines):\n" + "\n".join(tail))
+        self._fail(input_path, error_msg, failure_error_type, details=detail, command=cmd_str_log)
+        raise AbAv1Error(error_msg, command=cmd_str_log, output=result.output, error_type=failure_error_type)
+
+    def _verify_output_exists(self, output_path: str, *, input_path: str, cmd_str_log: str) -> None:
+        """Raise OutputFileError if a run reported success but produced no file."""
+        if os.path.exists(output_path):
+            return
+        error_msg = f"ab-av1 reported success (rc=0) but output file is missing: {anonymize_filename(output_path)}"
+        logger.error(error_msg)
+        self._fail(input_path, error_msg, "missing_output_on_success")
+        raise OutputFileError(error_msg, command=cmd_str_log, error_type="missing_output_on_success")
+
+    def _run_with_vmaf_fallback(
+        self,
+        *,
+        input_path: str,
+        initial_target: int,
+        make_cmd: Callable[[int], tuple[list[str], str]],
+        cwd: str,
+        on_attempt_start: Callable[[int, str], None],
+        on_line: Callable[[str], None] | None,
+        cancel_event: Any | None,
+        pid_callback: Callable[..., Any] | None,
+        original_size: int | None,
+        verbose_ffmpeg: bool,
+    ) -> tuple[ProcessResult, int, str]:
+        """Run ab-av1, decrementing the VMAF target on "no suitable crf" failures.
+
+        Args:
+            make_cmd: Builds (real command, anonymized command string) for a target.
+            cwd: Working directory for the process; ab-av1 temp folders appear
+                (and are cleaned) there.
+            on_attempt_start: Called with (target, anonymized command) before each attempt.
+            verbose_ffmpeg: See _process_env.
+
+        Returns:
+            (successful ProcessResult, VMAF target used, anonymized command string).
+
+        Raises:
+            AbAv1CancelledError: The run was cancelled via cancel_event.
+            ConversionNotWorthwhileError: No suitable CRF even at the minimum target.
+            AbAv1Error: Silence timeout or any other non-recoverable failure.
+        """
+        env = self._process_env(verbose_ffmpeg)
+        anonymized_input = anonymize_filename(input_path)
+        target = initial_target
+
+        while True:
+            # Don't spawn a doomed process for the next fallback step after the
+            # user already requested cancellation.
+            if cancel_event is not None and cancel_event.is_set():
+                clean_ab_av1_temp_folders(cwd)
+                logger.info(f"ab-av1 run cancelled before VMAF {target} attempt for {anonymized_input}")
+                raise AbAv1CancelledError("Cancelled by user", error_type="cancelled")
+
+            cmd, cmd_str_log = make_cmd(target)
+            logger.info(f"[Attempt VMAF {target}] Running: {cmd_str_log}")
+            on_attempt_start(target, cmd_str_log)
+
+            result = self._run_once(
+                cmd,
+                input_path=input_path,
+                cwd=cwd,
+                env=env,
+                on_line=on_line,
+                cancel_event=cancel_event,
+                pid_callback=pid_callback,
+            )
+
+            if result.cancelled or result.silence_timeout:
+                self._raise_for_failed_result(
+                    result,
+                    input_path=input_path,
+                    cmd_str_log=cmd_str_log,
+                    cleanup_dir=cwd,
+                    failure_error_type="ab_av1_failed",
+                )
+
+            if result.return_code == 0:
+                logger.info(f"ab-av1 succeeded for {anonymized_input} at VMAF target {target}")
+                return result, target, cmd_str_log
+
+            if _is_no_suitable_crf(result):
+                clean_ab_av1_temp_folders(cwd)
+                next_target = target - VMAF_FALLBACK_STEP
+                if next_target >= MIN_VMAF_FALLBACK_TARGET:
+                    logger.info(f"No suitable CRF at VMAF {target}; retrying {anonymized_input} at {next_target}")
+                    target = next_target
+                    continue
+                error_msg = (
+                    f"No efficient conversion possible - CRF search failed even at VMAF {MIN_VMAF_FALLBACK_TARGET}"
+                )
+                logger.info(f"File not worth converting: {anonymized_input}")
+                if self.file_info_callback:
+                    self.file_info_callback(
+                        os.path.basename(input_path),
+                        "skipped_not_worth",
+                        {
+                            "message": error_msg,
+                            "original_size": original_size,
+                            "min_vmaf_attempted": MIN_VMAF_FALLBACK_TARGET,
+                        },
+                    )
+                raise ConversionNotWorthwhileError(
+                    error_msg, command=cmd_str_log, output=result.output, original_size=original_size
+                )
+
+            # Non-recoverable failure - no retry
+            self._raise_for_failed_result(
+                result,
+                input_path=input_path,
+                cmd_str_log=cmd_str_log,
+                cleanup_dir=cwd,
+                failure_error_type="ab_av1_failed",
+            )
+
+    # --- Public operations ---
+
     def auto_encode(
         self,
         input_path: str,
@@ -71,8 +346,9 @@ class AbAv1Wrapper:
         pid_callback: Callable[..., Any] | None = None,
         total_duration_seconds: float = 0.0,
         hw_decoder: str | None = None,
-    ) -> dict[str, Any]:
-        """Run ab-av1 auto-encode with VMAF fallback loop using simple blocking reads.
+        cancel_event: Any | None = None,
+    ) -> EncodeStats:
+        """Run ab-av1 auto-encode (CRF search + encode) with VMAF fallback.
 
         Args:
             input_path: Path to the input video file.
@@ -81,124 +357,47 @@ class AbAv1Wrapper:
             pid_callback: Optional callback to receive the process ID.
             total_duration_seconds: Total duration of the input video in seconds.
             hw_decoder: Optional hardware decoder name (e.g., "h264_cuvid", "hevc_qsv").
+            cancel_event: Optional threading.Event; when set, the run is aborted
+                mid-process and AbAv1CancelledError is raised.
 
         Returns:
-            Dictionary containing encoding statistics and results.
+            EncodeStats with final statistics and timing breakdown.
 
         Raises:
-            InputFileError, OutputFileError, VMAFError, EncodingError, AbAv1Error
+            InputFileError, OutputFileError, AbAv1CancelledError,
+            ConversionNotWorthwhileError, AbAv1Error
         """
         self.file_info_callback = file_info_callback
-        self.parser.file_info_callback = file_info_callback  # Ensure parser has callback
+        self.parser.file_info_callback = file_info_callback
         preset = DEFAULT_ENCODING_PRESET
-        initial_min_vmaf = DEFAULT_VMAF_TARGET
+        initial_target = DEFAULT_VMAF_TARGET
 
-        # Track timing for CRF search vs encoding phases
         process_start_time = time.time()
-        encoding_phase_start_time: float | None = None
-
         anonymized_input_path = anonymize_filename(input_path)
 
-        # --- Input Validation ---
-        if not os.path.exists(input_path):
-            error_msg = f"Input not found: {anonymized_input_path}"
-            logger.error(error_msg)
-            if self.file_info_callback:
-                self.file_info_callback(
-                    os.path.basename(input_path), "failed", {"message": error_msg, "type": "missing_input"}
-                )
-            raise InputFileError(error_msg, error_type="missing_input")
-
-        try:
-            video_info = get_video_info(input_path)
-            if not video_info or "streams" not in video_info:
-                raise InputFileError("Invalid video file", error_type="invalid_video")
-
-            if not extract_video_metadata(video_info).has_video:
-                raise InputFileError("No video stream", error_type="no_video_stream")
-
-            try:
-                original_size = os.path.getsize(input_path)
-                stats = {"original_size": original_size}
-                logger.info(f"Original file size: {original_size} bytes ({format_file_size(original_size)})")
-            except Exception as size_e:
-                logger.warning(f"Couldn't get original file size: {size_e}")
-                stats = {}
-        except AbAv1Error:
-            raise
-        except Exception as e:
-            error_msg = f"Error analyzing {anonymized_input_path}"
-            logger.exception(error_msg)
-            if self.file_info_callback:
-                self.file_info_callback(
-                    os.path.basename(input_path), "failed", {"message": error_msg, "type": "analysis_failed"}
-                )
-            raise InputFileError(error_msg, error_type="analysis_failed") from e
-
-        # --- Output Path Setup ---
-        if not output_path.lower().endswith(".mkv"):
-            output_path = os.path.splitext(output_path)[0] + ".mkv"
-
-        output_dir = os.path.dirname(output_path)
-        try:
-            os.makedirs(output_dir, exist_ok=True)
-        except Exception as e:
-            error_msg = "Cannot create output dir"
-            logger.exception(error_msg)
-            if self.file_info_callback:
-                self.file_info_callback(
-                    os.path.basename(input_path), "failed", {"message": error_msg, "type": "output_dir_creation_failed"}
-                )
-            raise OutputFileError(error_msg, error_type="output_dir_creation_failed") from e
-
+        _video_info, original_size = self._validate_input(input_path)
+        output_path, output_dir = self._prepare_output(input_path, output_path)
         anonymized_output_path = anonymize_filename(output_path)
 
-        # --- VMAF Fallback Loop ---
-        current_vmaf_target = initial_min_vmaf
-        last_error_info = None
-        success = False
+        log_interval = get_log_interval_for_duration(total_duration_seconds)
+        if log_interval:
+            logger.info(f"Using log interval: {log_interval}")
 
-        if not stats:
-            stats = {}
-
-        stats.update(
-            {
-                "phase": "crf-search",
-                "progress_quality": 0,
-                "progress_encoding": 0,
-                "vmaf": None,
-                "crf": None,
-                "size_reduction": None,
-                "input_path": input_path,
-                "output_path": output_path,
-                "command": "",
-                "vmaf_target_used": current_vmaf_target,
-                "last_ffmpeg_fps": None,
-                "eta_text": None,
-                "total_duration_seconds": total_duration_seconds,
-                "last_reported_encoding_progress": -1.0,
-                "estimated_output_size": None,
-                "estimated_size_reduction": None,
-            }
+        stats = EncodeStats(
+            input_path=input_path,
+            output_path=output_path,
+            original_size=original_size,
+            total_duration_seconds=total_duration_seconds,
+            vmaf_target_used=initial_target,
         )
 
-        while current_vmaf_target >= MIN_VMAF_FALLBACK_TARGET:
-            # Reset stats for this attempt
-            stats["phase"] = "crf-search"
-            stats["progress_quality"] = 0
-            stats["progress_encoding"] = 0
-            stats["vmaf"] = None
-            stats["crf"] = None
-            stats["last_reported_encoding_progress"] = -1.0
-            stats["vmaf_target_used"] = current_vmaf_target
-            stats["estimated_output_size"] = None
-            stats["estimated_size_reduction"] = None
-            stats["eta_text"] = None
-            stats["last_ffmpeg_fps"] = None
+        log_replacements = {
+            self.executable_path: os.path.basename(self.executable_path),
+            input_path: os.path.basename(anonymized_input_path),
+            output_path: os.path.basename(anonymized_output_path),
+        }
 
-            logger.info(f"[Attempt VMAF {current_vmaf_target}] Starting for {anonymized_input_path}")
-
-            # --- Command Preparation ---
+        def make_cmd(target: int) -> tuple[list[str], str]:
             cmd = [
                 self.executable_path,
                 "auto-encode",
@@ -209,439 +408,93 @@ class AbAv1Wrapper:
                 "--preset",
                 str(preset),
                 "--min-vmaf",
-                str(current_vmaf_target),
+                str(target),
             ]
-
-            # Add hardware decoder if specified
             if hw_decoder:
                 cmd.extend(["--enc-input", f"c:v={hw_decoder}"])
-                logger.info(f"Using hardware decoder: {hw_decoder}")
-
-            # Add log interval if supported (for more frequent progress updates)
-            log_interval = get_log_interval_for_duration(total_duration_seconds)
             if log_interval:
                 cmd.extend(["--log-interval", log_interval])
-                logger.info(f"Using log interval: {log_interval}")
+            return cmd, _format_cmd_for_log(cmd, log_replacements)
 
-            cmd_str = " ".join(cmd)
-
-            cmd_for_log = [
-                os.path.basename(self.executable_path),
-                "auto-encode",
-                "-i",
-                os.path.basename(anonymized_input_path),
-                "-o",
-                os.path.basename(anonymized_output_path),
-                "--preset",
-                str(preset),
-                "--min-vmaf",
-                str(current_vmaf_target),
-            ]
-            if log_interval:
-                cmd_for_log.extend(["--log-interval", log_interval])
-            cmd_str_log = " ".join(cmd_for_log)
-            stats["command"] = cmd_str_log
-            logger.debug(f"Running: {cmd_str_log}")
-
-            # --- Environment Setup with maximum verbosity and pass-through flags ---
-            process_env = os.environ.copy()
-            # If vendor FFmpeg exists, prepend it to PATH so ab-av1 finds it
-            # This only affects this subprocess - user's system PATH is unchanged
-            if FFMPEG_DIR.exists():
-                process_env["PATH"] = str(FFMPEG_DIR) + os.pathsep + process_env.get("PATH", "")
-                logger.debug(f"Using vendor FFmpeg from {FFMPEG_DIR}")
-            # Critical environment variables for ffmpeg output
-            process_env["RUST_LOG"] = "debug,ab_av1=trace,ffmpeg=trace"  # Filter out trace from other components
-            process_env["AV1_PRINT_FFMPEG"] = "1"  # Force printing of ffmpeg output
-            process_env["AV1_RAW_OUTPUT"] = "1"  # Pass through raw output
-            process_env["FFMPEG_PROGRESS"] = "1"  # Try to enable any ffmpeg progress features
-            process_env["SVT_VERBOSE"] = "1"  # Try to enable SVT-AV1 verbosity
-            process_env["AB_AV1_VERBOSE"] = "1"  # Enable any ab-av1 verbosity
-            process_env["AB_AV1_LOG_PROGRESS"] = "1"  # Try to enable any progress logging
-            logger.info("Set targeted environment variable verbosity for ab-av1 and ffmpeg tools")
-
-            # --- Starting/Retrying Callback ---
+        def on_attempt_start(target: int, cmd_str_log: str) -> None:
+            stats.reset_for_attempt(target)
+            stats.command = cmd_str_log
             if self.file_info_callback:
                 callback_info = {
                     "message": "",
-                    "original_vmaf": initial_min_vmaf,
-                    "fallback_vmaf": current_vmaf_target,
-                    "used_fallback": current_vmaf_target != initial_min_vmaf,
-                    "vmaf_target_used": current_vmaf_target,
-                    "original_size": stats.get("original_size"),
+                    "original_vmaf": initial_target,
+                    "fallback_vmaf": target,
+                    "used_fallback": target != initial_target,
+                    "vmaf_target_used": target,
+                    "original_size": original_size,
                 }
-
-                if current_vmaf_target != initial_min_vmaf:
-                    callback_info["message"] = f"Retrying with VMAF target: {current_vmaf_target}"
+                if target != initial_target:
+                    callback_info["message"] = f"Retrying with VMAF target: {target}"
                     self.file_info_callback(os.path.basename(input_path), "retrying", callback_info)
                 else:
-                    status = "starting" if stats.get("original_size") is not None else "starting_no_size"
+                    status = "starting" if original_size is not None else "starting_no_size"
                     self.file_info_callback(os.path.basename(input_path), status, callback_info)
 
-            # --- Process Execution & Simple Blocking Read ---
-            process = None
-            return_code = -1
-            full_output_text = ""
-            read_loop_exception = None
+        encoding_phase_start: list[float | None] = [None]
 
-            try:
-                startupinfo, creationflags = get_windows_subprocess_startupinfo()
+        def on_line(line: str) -> None:
+            self.parser.parse_line(line, stats)
+            if encoding_phase_start[0] is None and stats.phase == "encoding":
+                encoding_phase_start[0] = time.time()
 
-                # Start the process, redirect stderr to stdout
-                process = subprocess.Popen(
-                    cmd,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
-                    universal_newlines=True,
-                    bufsize=1,
-                    cwd=output_dir,
-                    startupinfo=startupinfo,
-                    creationflags=creationflags,
-                    encoding="utf-8",
-                    errors="replace",
-                    env=process_env,
-                )
-
-                # Send PID to callback if provided
-                if pid_callback:
-                    pid_callback(process.pid)
-
-                # Simple blocking readline loop
-                logger.info(f"ab-av1 process {process.pid} started. Reading output...")
-                current_output_lines = []
-
-                assert process.stdout is not None  # Guaranteed by stdout=PIPE  # noqa: S101
-                try:
-                    for raw_line in iter(process.stdout.readline, ""):
-                        line = raw_line.strip()
-                        if not line:
-                            continue
-
-                        # Filter out sled::pagecache trace messages (internal Rust crate noise)
-                        if "sled::pagecache" in line:
-                            continue
-
-                        current_output_lines.append(line + "\n")
-                        stats = self.parser.parse_line(line, stats)  # Process every line
-
-                        # Detect phase transition to encoding for timing
-                        if encoding_phase_start_time is None and stats.get("phase") == "encoding":
-                            encoding_phase_start_time = time.time()
-                except Exception as loop_err:
-                    read_loop_exception = loop_err
-                    logger.error(f"Exception in read loop: {loop_err}", exc_info=True)
-
-                # --- Check process status after pipe reading completes ---
-                final_poll_code = process.poll()
-                logger.info(f"Status check after pipe reading: process.poll() returned {final_poll_code}")
-
-                # Close file handles (stderr is None when using STDOUT redirect)
-                try:
-                    if process.stdout:
-                        process.stdout.close()
-                except Exception as e:
-                    logger.warning(f"Error closing process stdout pipe: {e}")
-
-                # Get the final return code
-                if final_poll_code is None:
-                    # Process is still running, we need to wait for it to finish
-                    logger.warning("Process is still running after pipe reading completed")
-                    try:
-                        return_code = process.wait(timeout=30)  # Wait up to 30 seconds
-                        logger.info(f"Process completed with return code {return_code}")
-                    except subprocess.TimeoutExpired:
-                        logger.exception("Process did not complete within timeout period, forcing termination")
-                        process.terminate()
-                        time.sleep(1)
-                        if process.poll() is None:
-                            process.kill()
-                        return_code = -1
-                else:
-                    # Process already finished
-                    return_code = final_poll_code
-
-                logger.info(f"Process final return code: {return_code}")
-                full_output_text = "".join(current_output_lines)
-
-                if read_loop_exception:
-                    # Raise errors after the process has exited
-                    raise AbAv1Error(
-                        f"Exception during pipe read: {read_loop_exception}",
-                        command=cmd_str,
-                        output=full_output_text,
-                        error_type="pipe_read_error",
-                    ) from read_loop_exception
-
-            except FileNotFoundError as e:
-                error_msg = f"Executable not found: {self.executable_path}"
-                logger.exception(error_msg)
-                if self.file_info_callback:
-                    self.file_info_callback(
-                        os.path.basename(input_path), "failed", {"message": error_msg, "type": "executable_not_found"}
-                    )
-                raise FileNotFoundError(error_msg) from e
-
-            except Exception as e:
-                # Catch exceptions from Popen or the loop exception re-raised above
-                error_msg = f"Failed to start or manage process during VMAF {current_vmaf_target}"
-                logger.exception(error_msg)
-
-                if self.file_info_callback:
-                    self.file_info_callback(
-                        os.path.basename(input_path),
-                        "failed",
-                        {"message": error_msg, "type": "process_management_failed"},
-                    )
-
-                # Try to clean up any runaway process
-                if process and process.poll() is None:
-                    try:
-                        logger.warning("Terminating/Killing runaway process due to error.")
-                        process.terminate()
-                        time.sleep(0.2)
-                        process.kill()
-                    except Exception as e:
-                        # DEBUG appropriate: secondary cleanup failure; main error already logged above
-                        logger.debug(f"Error terminating process: {e}")
-
-                # Prepare output for error reporting
-                full_output_text = "".join(current_output_lines)
-                return_code = process.poll() if process else -1
-
-                # Re-raise appropriate exception
-                if not isinstance(e, (AbAv1Error, FileNotFoundError)):
-                    # Avoid re-wrapping known types
-                    raise AbAv1Error(
-                        error_msg, command=cmd_str, output=full_output_text, error_type="process_management_failed"
-                    ) from e
-                raise  # Re-raise the original known exception
-
-            # --- Check Result ---
-            logger.debug(f"Checking result for VMAF {current_vmaf_target}. RC={return_code}")
-            if return_code == 0:
-                if not os.path.exists(output_path):
-                    error_msg = f"ab-av1 reported success (rc=0) but output file is missing: {anonymized_output_path}"
-                    logger.error(error_msg)
-                    last_error_info = {
-                        "return_code": return_code,
-                        "error_type": "missing_output_on_success",
-                        "error_details": error_msg,
-                        "command": cmd_str_log,
-                        "output_tail": full_output_text.splitlines()[-20:],
-                    }
-                else:
-                    success = True
-                    logger.info(
-                        f"Encode succeeded (rc=0) for {anonymized_input_path} with VMAF target {current_vmaf_target}"
-                    )
-                    break
-            else:
-                # --- Error Handling and Fallback Logic ---
-                error_type = "unknown"
-                error_details = "Unknown error"
-                logger.debug("Analyzing failed run output...")
-                logger.debug(f"Output Text for Analysis (last 1000 chars):\n'''\n{full_output_text[-1000:]}\n'''")
-
-                # Analyze error by looking for common patterns in the output
-                if re.search(r"Failed\s+to\s+find\s+a\s+suitable\s+crf", full_output_text, re.IGNORECASE):
-                    logger.info("Detected 'Failed to find a suitable crf' error.")
-                    error_type = "crf_search_failed"
-                    error_details = f"Could not find suitable CRF for VMAF {current_vmaf_target}"
-
-                    # Check if this is the last attempt (minimum VMAF reached)
-                    if current_vmaf_target <= MIN_VMAF_FALLBACK_TARGET:
-                        # This means conversion isn't worthwhile
-                        error_msg = (
-                            f"No efficient conversion possible - CRF search failed even at "
-                            f"VMAF {MIN_VMAF_FALLBACK_TARGET}"
-                        )
-                        logger.info(f"File not worth converting: {anonymized_input_path}")
-
-                        if self.file_info_callback:
-                            self.file_info_callback(
-                                os.path.basename(input_path),
-                                "skipped_not_worth",
-                                {
-                                    "message": error_msg,
-                                    "original_size": stats.get("original_size"),
-                                    "min_vmaf_attempted": MIN_VMAF_FALLBACK_TARGET,
-                                },
-                            )
-
-                        clean_ab_av1_temp_folders(output_dir)
-                        raise ConversionNotWorthwhileError(
-                            error_msg,
-                            command=cmd_str_log,
-                            output=full_output_text,
-                            original_size=stats.get("original_size"),
-                        )
-                elif re.search(r"ffmpeg.*?:\s*Invalid\s+data\s+found", full_output_text, re.IGNORECASE):
-                    error_type = "invalid_input_data"
-                    error_details = "Invalid data in input"
-                elif re.search(r"No\s+such\s+file\s+or\s+directory", full_output_text, re.IGNORECASE):
-                    error_type = "file_not_found"
-                    error_details = "Input not found/inaccessible"
-                elif re.search(r"failed\s+to\s+open\s+file", full_output_text, re.IGNORECASE):
-                    error_type = "file_open_failed"
-                    error_details = "Failed to open input"
-                elif re.search(r"permission\s+denied", full_output_text, re.IGNORECASE):
-                    error_type = "permission_denied"
-                    error_details = "Permission denied"
-                elif re.search(r"vmaf\s+.*?error", full_output_text, re.IGNORECASE):
-                    error_type = "vmaf_calculation_failed"
-                    error_details = "VMAF calculation failed"
-                elif re.search(r"encode\s+.*?error", full_output_text, re.IGNORECASE):
-                    error_type = "encoding_failed"
-                    error_details = "Encoding failed"
-                elif re.search(r"out\s+of\s+memory", full_output_text, re.IGNORECASE):
-                    error_type = "memory_error"
-                    error_details = "Out of memory"
-                elif AB_AV1_EXE_NAME in full_output_text and "not recognized" in full_output_text:
-                    error_type = "executable_not_found"
-                    error_details = f"{AB_AV1_EXE_NAME} command failed (not found or path issue?)"
-                elif return_code != 0:
-                    error_details = f"ab-av1 exited with code {return_code}"
-                    logger.info(f"No specific error pattern matched, using generic exit code message: {error_details}")
-
-                last_error_info = {
-                    "return_code": return_code,
-                    "error_type": error_type,
-                    "error_details": error_details,
-                    "command": cmd_str_log,
-                    "output_tail": full_output_text.splitlines()[-20:]
-                    if full_output_text
-                    else ["<No output captured>"],
-                }
-                logger.warning(
-                    f"[Attempt VMAF {current_vmaf_target}] Failed (rc={return_code}): "
-                    f"{error_details} (Type: {error_type})"
-                )
-
-                # Handle fallback for CRF search failures
-                logger.debug(f"Checking if error type '{error_type}' triggers VMAF fallback...")
-                if error_type == "crf_search_failed":
-                    current_vmaf_target -= VMAF_FALLBACK_STEP
-                    if current_vmaf_target >= MIN_VMAF_FALLBACK_TARGET:
-                        logger.info(f"--> Retrying {anonymized_input_path} with VMAF target: {current_vmaf_target}")
-                        clean_ab_av1_temp_folders(output_dir)
-                        continue
-                    logger.error(f"CRF search failed down to minimum VMAF {MIN_VMAF_FALLBACK_TARGET}. Stopping.")
-                    last_error_info["error_details"] = f"CRF search failed down to VMAF {MIN_VMAF_FALLBACK_TARGET}"
-                    break
-                logger.error(f"Non-recoverable error type '{error_type}'. Stopping attempts for this file.")
-                clean_ab_av1_temp_folders(output_dir)
-                break
-
-        # --- End of VMAF Fallback Loop ---
-
-        # --- Failure Reporting ---
-        if not success:
-            clean_ab_av1_temp_folders(output_dir)
-            if last_error_info:
-                error_msg = f"ab-av1 failed (rc={last_error_info['return_code']}): {last_error_info['error_details']}"
-                logger.error(error_msg)
-                logger.error(f"Last Cmd: {last_error_info['command']}")
-                logger.error(
-                    f"Last Output tail ({len(last_error_info['output_tail'])} lines):\n"
-                    f"{''.join(last_error_info['output_tail'])}"
-                )
-
-                if self.file_info_callback:
-                    self.file_info_callback(
-                        os.path.basename(input_path),
-                        "failed",
-                        {
-                            "message": error_msg,
-                            "type": last_error_info["error_type"],
-                            "details": last_error_info["error_details"],
-                            "command": last_error_info["command"],
-                        },
-                    )
-
-                # Map error types to exception classes
-                error_type = last_error_info["error_type"]
-                exc_map = {
-                    "invalid_input_data": InputFileError,
-                    "file_not_found": InputFileError,
-                    "file_open_failed": InputFileError,
-                    "no_video_stream": InputFileError,
-                    "analysis_failed": InputFileError,
-                    "vmaf_calculation_failed": VMAFError,
-                    "encoding_failed": EncodingError,
-                    "memory_error": EncodingError,
-                    "crf_search_failed": EncodingError,
-                    "executable_not_found": EncodingError,
-                    "permission_denied": EncodingError,
-                    "output_dir_creation_failed": OutputFileError,
-                    "rename_failed": OutputFileError,
-                    "missing_output_on_success": OutputFileError,
-                    "pipe_read_error": AbAv1Error,
-                }
-                exception_class = exc_map.get(error_type, AbAv1Error)
-                raise exception_class(
-                    error_msg, command=last_error_info["command"], output=full_output_text, error_type=error_type
-                )
-            generic_error_msg = f"Encode failed for {anonymized_input_path} for unknown reasons after loop."
-            logger.error(generic_error_msg)
-            if self.file_info_callback:
-                self.file_info_callback(
-                    os.path.basename(input_path), "failed", {"message": generic_error_msg, "type": "unknown_loop_error"}
-                )
-            raise AbAv1Error(generic_error_msg, error_type="unknown_loop_error")
+        result, target_used, cmd_str_log = self._run_with_vmaf_fallback(
+            input_path=input_path,
+            initial_target=initial_target,
+            make_cmd=make_cmd,
+            cwd=output_dir,
+            on_attempt_start=on_attempt_start,
+            on_line=on_line,
+            cancel_event=cancel_event,
+            pid_callback=pid_callback,
+            original_size=original_size,
+            verbose_ffmpeg=True,
+        )
 
         # --- Success Path ---
-        logger.info(
-            f"ab-av1 completed successfully for {anonymized_input_path} "
-            f"(used VMAF target {stats.get('vmaf_target_used', '?')})"
-        )
-        stats = self.parser.parse_final_output(full_output_text, stats)
+        self._verify_output_exists(output_path, input_path=input_path, cmd_str_log=cmd_str_log)
+
+        logger.info(f"ab-av1 completed successfully for {anonymized_input_path} (used VMAF target {target_used})")
+        self.parser.parse_final_output(result.output, stats)
 
         # --- Calculate timing breakdown ---
         now = time.time()
-        if encoding_phase_start_time is not None:
-            stats["crf_search_time_sec"] = encoding_phase_start_time - process_start_time
-            stats["encoding_time_sec"] = now - encoding_phase_start_time
+        if encoding_phase_start[0] is not None:
+            stats.crf_search_time_sec = encoding_phase_start[0] - process_start_time
+            stats.encoding_time_sec = now - encoding_phase_start[0]
         else:
             # Fallback: couldn't detect phase transition (shouldn't happen normally)
-            stats["crf_search_time_sec"] = now - process_start_time
-            stats["encoding_time_sec"] = 0
+            stats.crf_search_time_sec = now - process_start_time
+            stats.encoding_time_sec = 0.0
 
         # --- Logging Final Stats ---
-        if stats.get("crf") is not None:
-            logger.info(f"Final CRF: {format_crf(stats['crf'])}")
-        if stats.get("vmaf") is not None:
-            logger.info(f"Final VMAF: {stats['vmaf']:.2f}")
-        if stats.get("size_reduction") is not None:
-            logger.info(f"Final Size reduction: {stats['size_reduction']:.2f}%")
+        if stats.crf is not None:
+            logger.info(f"Final CRF: {format_crf(stats.crf)}")
+        if stats.vmaf is not None:
+            logger.info(f"Final VMAF: {stats.vmaf:.2f}")
+        if stats.size_reduction is not None:
+            logger.info(f"Final Size reduction: {stats.size_reduction:.2f}%")
         else:
             logger.warning("Final size reduction could not be determined from parsing.")
 
-        # --- Post-Success Sanity Checks ---
-        if not os.path.exists(output_path):
-            error_msg = f"CRITICAL: Output file missing after reported success: {anonymized_output_path}"
-            logger.error(error_msg)
-            if self.file_info_callback:
-                self.file_info_callback(
-                    os.path.basename(input_path),
-                    "failed",
-                    {"message": error_msg, "type": "missing_output_post_success"},
-                )
-            raise OutputFileError(error_msg, command=cmd_str_log, error_type="missing_output_post_success")
-
         # --- Completion Callback ---
         if self.file_info_callback:
+            vmaf_text = f"{stats.vmaf:.2f}" if stats.vmaf is not None else "N/A"
             final_stats_for_callback = {
-                "message": (
-                    f"Complete (VMAF {stats.get('vmaf', 'N/A'):.2f} @ Target {stats.get('vmaf_target_used', '?')})"
-                ),
-                "vmaf": stats.get("vmaf"),
-                "crf": stats.get("crf"),
-                "vmaf_target_used": stats.get("vmaf_target_used"),
-                "size_reduction": stats.get("size_reduction"),
+                "message": f"Complete (VMAF {vmaf_text} @ Target {target_used})",
+                "vmaf": stats.vmaf,
+                "crf": stats.crf,
+                "vmaf_target_used": stats.vmaf_target_used,
+                "size_reduction": stats.size_reduction,
                 "output_path": output_path,
             }
             try:
                 final_size = os.path.getsize(output_path)
+                stats.output_size = final_size
                 final_stats_for_callback["output_size"] = final_size
                 logger.info(f"Final output size: {final_size} bytes ({format_file_size(final_size)})")
             except Exception as size_e:
@@ -650,12 +503,9 @@ class AbAv1Wrapper:
             self.file_info_callback(os.path.basename(input_path), "completed", final_stats_for_callback)
 
         # --- Temp Folder Cleanup (Final Check) ---
-        cleanup_dir = os.path.dirname(output_path)
-        cleaned_count = clean_ab_av1_temp_folders(cleanup_dir)
+        cleaned_count = clean_ab_av1_temp_folders(output_dir)
         if cleaned_count > 0:
-            logger.info(f"Cleaned {cleaned_count} leftover temporary folder(s) in {cleanup_dir}.")
-        else:
-            logger.debug(f"No leftover temporary folders found to clean in {cleanup_dir}.")
+            logger.info(f"Cleaned {cleaned_count} leftover temporary folder(s) in {output_dir}.")
 
         # --- Clear Callbacks ---
         self.file_info_callback = None
@@ -670,14 +520,12 @@ class AbAv1Wrapper:
         progress_callback: Callable[..., Any] | None = None,
         stop_event: Any | None = None,
         hw_decoder: str | None = None,
-    ) -> dict[str, Any]:
+        pid_callback: Callable[..., Any] | None = None,
+    ) -> CrfSearchResult:
         """Run ab-av1 crf-search with VMAF fallback (no full encoding).
 
         This performs VMAF-targeted CRF search by sampling the video at multiple
         CRF values to find the optimal quality setting. Does NOT encode the full video.
-
-        Uses the same VMAF fallback logic as auto_encode: if the initial VMAF target
-        cannot be achieved, automatically retries with lower targets (95→94→...→90).
 
         Args:
             input_path: Path to the input video file.
@@ -685,76 +533,45 @@ class AbAv1Wrapper:
             preset: SVT-AV1 encoding preset (default: DEFAULT_ENCODING_PRESET).
             progress_callback: Optional callback for progress updates.
                 Signature: callback(progress_percent, message)
-            stop_event: Optional threading.Event to signal cancellation.
+            stop_event: Optional threading.Event to signal cancellation (aborts mid-run).
             hw_decoder: Optional hardware decoder name (e.g., "h264_cuvid", "hevc_qsv").
+            pid_callback: Optional callback to receive the process ID (for force-stop).
 
         Returns:
-            Dictionary containing:
-                - best_crf: float - Optimal CRF value found (fractional since ab-av1 0.11)
-                - best_vmaf: float - VMAF score achieved at best CRF
-                - predicted_size_reduction: float - Predicted size reduction percentage
-                - predicted_output_size: int | None - Estimated output file size in bytes
-                - vmaf_target_used: int - Actual VMAF target that succeeded (may be lower than requested)
-                - used_fallback: bool - True if a lower VMAF target was used
+            CrfSearchResult with the optimal CRF, achieved VMAF, and predictions.
 
         Raises:
             InputFileError: If input file is missing or invalid
+            AbAv1CancelledError: If the search was cancelled via stop_event
             ConversionNotWorthwhileError: If CRF search fails at all VMAF targets down to minimum
             AbAv1Error: For other ab-av1 execution errors
         """
+        # No file_info_callback for analysis runs - progress flows through progress_callback
+        self.file_info_callback = None
+        self.parser.file_info_callback = None
+
         if vmaf_target is None:
             vmaf_target = DEFAULT_VMAF_TARGET
         if preset is None:
             preset = DEFAULT_ENCODING_PRESET
 
-        crf_search_start_time = time.time()  # Track CRF search duration
-
-        initial_vmaf_target = vmaf_target
+        crf_search_start_time = time.time()
+        initial_target = vmaf_target
         anonymized_input_path = anonymize_filename(input_path)
 
-        # --- Input Validation ---
-        if not os.path.exists(input_path):
-            error_msg = f"Input not found: {anonymized_input_path}"
-            logger.error(error_msg)
-            raise InputFileError(error_msg, error_type="missing_input")
+        video_info, original_size = self._validate_input(input_path)
 
-        try:
-            video_info = get_video_info(input_path)
-            if not video_info or "streams" not in video_info:
-                raise InputFileError("Invalid video file", error_type="invalid_video")
+        # Use input file's directory as cwd so temp folders are created (and cleaned) there
+        input_dir = os.path.dirname(input_path) or os.getcwd()
 
-            if not extract_video_metadata(video_info).has_video:
-                raise InputFileError("No video stream", error_type="no_video_stream")
+        stats = EncodeStats(input_path=input_path, original_size=original_size, vmaf_target_used=initial_target)
 
-            try:
-                original_size = os.path.getsize(input_path)
-                logger.info(f"Original file size: {original_size} bytes ({format_file_size(original_size)})")
-            except Exception as size_e:
-                logger.warning(f"Couldn't get original file size: {size_e}")
-                original_size = None
-        except AbAv1Error:
-            raise
-        except Exception as e:
-            error_msg = f"Error analyzing {anonymized_input_path}"
-            logger.exception(error_msg)
-            raise InputFileError(error_msg, error_type="analysis_failed") from e
+        log_replacements = {
+            self.executable_path: os.path.basename(self.executable_path),
+            input_path: os.path.basename(anonymized_input_path),
+        }
 
-        # --- Environment Setup ---
-        process_env = os.environ.copy()
-        process_env["RUST_LOG"] = "debug,ab_av1=trace"
-        process_env["AV1_PRINT_FFMPEG"] = "1"
-
-        # --- VMAF Fallback Loop ---
-        current_vmaf_target = initial_vmaf_target
-        cmd_str_log = ""
-        full_output_text = ""
-
-        while current_vmaf_target >= MIN_VMAF_FALLBACK_TARGET:
-            # Check for cancellation before starting new attempt
-            if stop_event and stop_event.is_set():
-                raise AbAv1Error("CRF search cancelled by user", error_type="cancelled")
-
-            # --- Command Preparation ---
+        def make_cmd(target: int) -> tuple[list[str], str]:
             cmd = [
                 self.executable_path,
                 "crf-search",
@@ -763,218 +580,95 @@ class AbAv1Wrapper:
                 "--preset",
                 str(preset),
                 "--min-vmaf",
-                str(current_vmaf_target),
+                str(target),
             ]
-
-            # Add hardware decoder if specified
             if hw_decoder:
                 cmd.extend(["--enc-input", f"c:v={hw_decoder}"])
+            return cmd, _format_cmd_for_log(cmd, log_replacements)
 
-            cmd_str = " ".join(cmd)
+        def on_attempt_start(target: int, cmd_str_log: str) -> None:
+            stats.reset_for_attempt(target)
+            stats.command = cmd_str_log
 
-            cmd_for_log = [
-                os.path.basename(self.executable_path),
-                "crf-search",
-                "-i",
-                os.path.basename(anonymized_input_path),
-                "--preset",
-                str(preset),
-                "--min-vmaf",
-                str(current_vmaf_target),
-            ]
-            cmd_str_log = " ".join(cmd_for_log)
+        # Only forward changed values: on_line fires for every output line, and each
+        # forwarded update ends up as a Tkinter root.after post on the main thread.
+        last_sent: list[tuple[float, float | None, float | None] | None] = [None]
 
-            if current_vmaf_target != initial_vmaf_target:
-                logger.info(f"Retrying CRF search with VMAF target {current_vmaf_target}: {cmd_str_log}")
-            else:
-                logger.info(f"Running CRF search: {cmd_str_log}")
+        def on_line(line: str) -> None:
+            self.parser.parse_line(line, stats)
+            if not (progress_callback and stats.progress_quality):
+                return
+            snapshot = (stats.progress_quality, stats.crf, stats.vmaf)
+            if snapshot == last_sent[0]:
+                return
+            last_sent[0] = snapshot
+            target = stats.vmaf_target_used
+            suffix = f" (target: {target})" if target != initial_target else ""
+            vmaf_text = stats.vmaf if stats.vmaf is not None else "?"
+            message = f"CRF:{format_crf(stats.crf)}, VMAF:{vmaf_text}{suffix}"
+            progress_callback(stats.progress_quality, message)
 
-            # Track parsed results
-            stats: dict[str, Any] = {
-                "phase": "crf-search",
-                "progress_quality": 0,
-                "vmaf": None,
-                "crf": None,
-                "size_reduction": None,
-                "original_size": original_size,
-                "vmaf_target_used": current_vmaf_target,
-            }
-
-            # --- Process Execution ---
-            process = None
-            return_code = -1
-            full_output_text = ""
-            current_output_lines: list[str] = []
-
-            try:
-                startupinfo, creationflags = get_windows_subprocess_startupinfo()
-
-                # Use input file's directory as cwd so temp folders are created there
-                # (matching where cleanup looks at lines 895 and 919)
-                input_dir = os.path.dirname(input_path) or os.getcwd()
-
-                process = subprocess.Popen(
-                    cmd,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
-                    universal_newlines=True,
-                    bufsize=1,
-                    cwd=input_dir,
-                    startupinfo=startupinfo,
-                    creationflags=creationflags,
-                    encoding="utf-8",
-                    errors="replace",
-                    env=process_env,
-                )
-
-                logger.info(f"CRF search process {process.pid} started. Reading output...")
-
-                assert process.stdout is not None  # Guaranteed by stdout=PIPE  # noqa: S101
-
-                # Read output line by line, checking stop_event periodically
-                for raw_line in iter(process.stdout.readline, ""):
-                    # Check if we should stop
-                    if stop_event and stop_event.is_set():
-                        logger.info("CRF search cancelled by stop event")
-                        process.terminate()
-                        time.sleep(0.5)
-                        if process.poll() is None:
-                            process.kill()
-                        raise AbAv1Error("CRF search cancelled by user", error_type="cancelled")
-
-                    line = raw_line.strip()
-                    if not line:
-                        continue
-
-                    # Filter out noise
-                    if "sled::pagecache" in line:
-                        continue
-
-                    current_output_lines.append(line + "\n")
-
-                    # Parse for progress
-                    stats = self.parser.parse_line(line, stats)
-
-                    # Send progress updates
-                    if progress_callback and stats.get("progress_quality"):
-                        if current_vmaf_target != initial_vmaf_target:
-                            vmaf_suffix = f" (target: {current_vmaf_target})"
-                        else:
-                            vmaf_suffix = ""
-                        message = f"CRF:{format_crf(stats.get('crf'))}, VMAF:{stats.get('vmaf', '?')}{vmaf_suffix}"
-                        progress_callback(stats["progress_quality"], message)
-
-                # Close stdout
-                try:
-                    if process.stdout:
-                        process.stdout.close()
-                except Exception as e:
-                    logger.warning(f"Error closing process stdout pipe: {e}")
-
-                # Get return code
-                return_code = process.wait(timeout=30)
-                logger.info(f"CRF search process return code: {return_code}")
-                full_output_text = "".join(current_output_lines)
-
-            except AbAv1Error:
-                # Re-raise cancellation and other AbAv1Errors
-                raise
-            except Exception as e:
-                error_msg = f"Failed to run CRF search: {e}"
-                logger.exception(error_msg)
-
-                # Clean up runaway process
-                if process and process.poll() is None:
-                    try:
-                        logger.warning("Terminating/Killing runaway process due to error.")
-                        process.terminate()
-                        time.sleep(0.2)
-                        process.kill()
-                    except Exception as kill_e:
-                        logger.debug(f"Error terminating process: {kill_e}")
-
-                full_output_text = "".join(current_output_lines)
-                raise AbAv1Error(error_msg, command=cmd_str, output=full_output_text, error_type="process_error") from e
-
-            # --- Parse Final Results ---
-            stats = self.parser.parse_final_output(full_output_text, stats)
-
-            # --- Check Result ---
-            if return_code == 0:
-                # Success! Verify we have results
-                if stats.get("crf") is None or stats.get("vmaf") is None:
-                    error_msg = "CRF search completed but could not parse results"
-                    logger.error(error_msg)
-                    logger.error(f"Output:\n{full_output_text[-1000:]}")
-                    raise AbAv1Error(error_msg, command=cmd_str_log, output=full_output_text, error_type="parse_error")
-
-                # Calculate predicted output size (accounting for audio which is copied unchanged)
-                predicted_output_size = None
-                if original_size and stats.get("size_reduction"):
-                    # ab-av1's size_reduction is video-only; audio is copied unchanged
-                    meta = extract_video_metadata(video_info)
-                    audio_size_bytes = 0
-                    if meta.duration_sec and meta.total_audio_bitrate_kbps:
-                        audio_size_bytes = int(meta.duration_sec * meta.total_audio_bitrate_kbps * 1000 / 8)
-
-                    # Apply reduction only to video portion
-                    video_size = max(0, original_size - audio_size_bytes)
-                    predicted_video = int(video_size * (1 - stats["size_reduction"] / 100))
-                    predicted_output_size = predicted_video + audio_size_bytes
-
-                # Build result
-                result = {
-                    "best_crf": stats["crf"],
-                    "best_vmaf": stats["vmaf"],
-                    "predicted_size_reduction": stats.get("size_reduction"),
-                    "predicted_output_size": predicted_output_size,
-                    "vmaf_target_used": current_vmaf_target,
-                    "original_size": original_size,
-                    "used_fallback": current_vmaf_target != initial_vmaf_target,
-                    "preset_used": preset,
-                    "crf_search_time_sec": time.time() - crf_search_start_time,
-                }
-
-                logger.info(
-                    f"CRF search complete: CRF={format_crf(result['best_crf'])}, "
-                    f"VMAF={result['best_vmaf']:.2f}, "
-                    f"Reduction={result.get('predicted_size_reduction', 'N/A')}%, "
-                    f"Target={current_vmaf_target}"
-                    f"{' (fallback)' if result['used_fallback'] else ''}"
-                )
-
-                # Clean up temp folders in input file's directory
-                input_dir = os.path.dirname(input_path)
-                if input_dir:
-                    clean_ab_av1_temp_folders(input_dir)
-
-                return result
-
-            # --- Handle Failure ---
-            if re.search(r"Failed\s+to\s+find\s+a\s+suitable\s+crf", full_output_text, re.IGNORECASE):
-                logger.info(f"CRF search failed at VMAF {current_vmaf_target}, trying lower target...")
-                current_vmaf_target -= VMAF_FALLBACK_STEP
-                # Clean up temp folders before retrying (matches auto_encode pattern)
-                input_dir = os.path.dirname(input_path)
-                if input_dir:
-                    clean_ab_av1_temp_folders(input_dir)
-                continue
-
-            # Other error - don't retry
-            error_msg = f"CRF search failed with exit code {return_code}"
-            logger.error(error_msg)
-            logger.error(f"Output tail:\n{full_output_text[-1000:]}")
-            raise AbAv1Error(error_msg, command=cmd_str_log, output=full_output_text, error_type="crf_search_error")
-
-        # --- All VMAF targets exhausted ---
-        error_msg = f"No efficient conversion possible - CRF search failed even at VMAF {MIN_VMAF_FALLBACK_TARGET}"
-        logger.info(f"File not worth converting: {anonymized_input_path}")
-        input_dir = os.path.dirname(input_path)
-        if input_dir:
-            clean_ab_av1_temp_folders(input_dir)
-        raise ConversionNotWorthwhileError(
-            error_msg, command=cmd_str_log, output=full_output_text, original_size=original_size
+        result, target_used, cmd_str_log = self._run_with_vmaf_fallback(
+            input_path=input_path,
+            initial_target=initial_target,
+            make_cmd=make_cmd,
+            cwd=input_dir,
+            on_attempt_start=on_attempt_start,
+            on_line=on_line,
+            cancel_event=stop_event,
+            pid_callback=pid_callback,
+            original_size=original_size,
+            verbose_ffmpeg=False,
         )
+
+        # --- Parse Final Results ---
+        self.parser.parse_final_output(result.output, stats)
+
+        if stats.crf is None or stats.vmaf is None:
+            error_msg = "CRF search completed but could not parse results"
+            logger.error(error_msg)
+            logger.error(f"Output:\n{result.output[-1000:]}")
+            raise AbAv1Error(error_msg, command=cmd_str_log, output=result.output, error_type="parse_error")
+
+        # Calculate predicted output size (accounting for audio which is copied unchanged)
+        predicted_output_size = None
+        if original_size and stats.size_reduction:
+            # ab-av1's size_reduction is video-only; audio is copied unchanged
+            meta = extract_video_metadata(video_info)
+            audio_size_bytes = 0
+            if meta.duration_sec and meta.total_audio_bitrate_kbps:
+                audio_size_bytes = int(meta.duration_sec * meta.total_audio_bitrate_kbps * 1000 / 8)
+
+            # Apply reduction only to video portion
+            video_size = max(0, original_size - audio_size_bytes)
+            predicted_video = int(video_size * (1 - stats.size_reduction / 100))
+            predicted_output_size = predicted_video + audio_size_bytes
+
+        search_result = CrfSearchResult(
+            best_crf=stats.crf,
+            best_vmaf=stats.vmaf,
+            predicted_size_reduction=stats.size_reduction,
+            predicted_output_size=predicted_output_size,
+            vmaf_target_used=target_used,
+            original_size=original_size,
+            used_fallback=target_used != initial_target,
+            preset_used=preset,
+            crf_search_time_sec=time.time() - crf_search_start_time,
+        )
+
+        reduction_text = (
+            f"{search_result.predicted_size_reduction}" if search_result.predicted_size_reduction is not None else "N/A"
+        )
+        logger.info(
+            f"CRF search complete: CRF={format_crf(search_result.best_crf)}, "
+            f"VMAF={search_result.best_vmaf:.2f}, "
+            f"Reduction={reduction_text}%, "
+            f"Target={target_used}"
+            f"{' (fallback)' if search_result.used_fallback else ''}"
+        )
+
+        clean_ab_av1_temp_folders(input_dir)
+        return search_result
 
     def encode_with_crf(
         self,
@@ -986,11 +680,11 @@ class AbAv1Wrapper:
         pid_callback: Callable[..., Any] | None = None,
         total_duration_seconds: float = 0.0,
         hw_decoder: str | None = None,
-    ) -> dict[str, Any]:
+        cancel_event: Any | None = None,
+    ) -> EncodeStats:
         """Run ab-av1 encode with explicit CRF (skip CRF search phase).
 
         Use this when you already know the optimal CRF from previous quality analysis.
-        This skips the CRF search phase entirely and goes straight to encoding.
 
         Args:
             input_path: Path to the input video file.
@@ -1001,12 +695,14 @@ class AbAv1Wrapper:
             pid_callback: Optional callback to receive the process ID.
             total_duration_seconds: Total duration of the input video in seconds.
             hw_decoder: Optional hardware decoder name (e.g., "h264_cuvid", "hevc_qsv").
+            cancel_event: Optional threading.Event; when set, the run is aborted
+                mid-process and AbAv1CancelledError is raised.
 
         Returns:
-            Dictionary containing encoding statistics and results.
+            EncodeStats with final statistics and timing breakdown.
 
         Raises:
-            InputFileError, OutputFileError, EncodingError, AbAv1Error
+            InputFileError, OutputFileError, AbAv1CancelledError, AbAv1Error
         """
         self.file_info_callback = file_info_callback
         self.parser.file_info_callback = file_info_callback
@@ -1014,62 +710,11 @@ class AbAv1Wrapper:
         if preset is None:
             preset = DEFAULT_ENCODING_PRESET
 
-        encoding_start_time = time.time()  # Track encoding duration (no CRF search)
-
+        encoding_start_time = time.time()
         anonymized_input_path = anonymize_filename(input_path)
 
-        # --- Input Validation ---
-        if not os.path.exists(input_path):
-            error_msg = f"Input not found: {anonymized_input_path}"
-            logger.error(error_msg)
-            if self.file_info_callback:
-                self.file_info_callback(
-                    os.path.basename(input_path), "failed", {"message": error_msg, "type": "missing_input"}
-                )
-            raise InputFileError(error_msg, error_type="missing_input")
-
-        try:
-            video_info = get_video_info(input_path)
-            if not video_info or "streams" not in video_info:
-                raise InputFileError("Invalid video file", error_type="invalid_video")
-
-            if not extract_video_metadata(video_info).has_video:
-                raise InputFileError("No video stream", error_type="no_video_stream")
-
-            try:
-                original_size = os.path.getsize(input_path)
-                stats: dict[str, Any] = {"original_size": original_size}
-                logger.info(f"Original file size: {original_size} bytes ({format_file_size(original_size)})")
-            except Exception as size_e:
-                logger.warning(f"Couldn't get original file size: {size_e}")
-                stats = {}
-        except AbAv1Error:
-            raise
-        except Exception as e:
-            error_msg = f"Error analyzing {anonymized_input_path}"
-            logger.exception(error_msg)
-            if self.file_info_callback:
-                self.file_info_callback(
-                    os.path.basename(input_path), "failed", {"message": error_msg, "type": "analysis_failed"}
-                )
-            raise InputFileError(error_msg, error_type="analysis_failed") from e
-
-        # --- Output Path Setup ---
-        if not output_path.lower().endswith(".mkv"):
-            output_path = os.path.splitext(output_path)[0] + ".mkv"
-
-        output_dir = os.path.dirname(output_path)
-        try:
-            os.makedirs(output_dir, exist_ok=True)
-        except Exception as e:
-            error_msg = "Cannot create output dir"
-            logger.exception(error_msg)
-            if self.file_info_callback:
-                self.file_info_callback(
-                    os.path.basename(input_path), "failed", {"message": error_msg, "type": "output_dir_creation_failed"}
-                )
-            raise OutputFileError(error_msg, error_type="output_dir_creation_failed") from e
-
+        _video_info, original_size = self._validate_input(input_path)
+        output_path, output_dir = self._prepare_output(input_path, output_path)
         anonymized_output_path = anonymize_filename(output_path)
 
         # --- Command Preparation ---
@@ -1085,57 +730,33 @@ class AbAv1Wrapper:
             "--crf",
             format_crf(crf),
         ]
-
-        # Add hardware decoder if specified
         if hw_decoder:
             cmd.extend(["--enc-input", f"c:v={hw_decoder}"])
-
-        # Add log interval if supported (for more frequent progress updates)
         log_interval = get_log_interval_for_duration(total_duration_seconds)
         if log_interval:
             cmd.extend(["--log-interval", log_interval])
             logger.info(f"Using log interval: {log_interval}")
 
-        cmd_str = " ".join(cmd)
-
-        cmd_for_log = [
-            os.path.basename(self.executable_path),
-            "encode",
-            "-i",
-            os.path.basename(anonymized_input_path),
-            "-o",
-            os.path.basename(anonymized_output_path),
-            "--preset",
-            str(preset),
-            "--crf",
-            format_crf(crf),
-        ]
-        if log_interval:
-            cmd_for_log.extend(["--log-interval", log_interval])
-        cmd_str_log = " ".join(cmd_for_log)
+        cmd_str_log = _format_cmd_for_log(
+            cmd,
+            {
+                self.executable_path: os.path.basename(self.executable_path),
+                input_path: os.path.basename(anonymized_input_path),
+                output_path: os.path.basename(anonymized_output_path),
+            },
+        )
         logger.info(f"Running encode with cached CRF: {cmd_str_log}")
 
-        # Update stats for encoding phase
-        stats.update(
-            {
-                "phase": "encoding",
-                "progress_quality": 100,  # CRF search already done
-                "progress_encoding": 0,
-                "vmaf": None,
-                "crf": crf,
-                "size_reduction": None,
-                "input_path": input_path,
-                "output_path": output_path,
-                "command": cmd_str_log,
-                "vmaf_target_used": None,  # Not applicable - using cached CRF
-                "last_ffmpeg_fps": None,
-                "eta_text": None,
-                "total_duration_seconds": total_duration_seconds,
-                "last_reported_encoding_progress": -1.0,
-                "estimated_output_size": None,
-                "estimated_size_reduction": None,
-                "used_cached_crf": True,
-            }
+        stats = EncodeStats(
+            input_path=input_path,
+            output_path=output_path,
+            command=cmd_str_log,
+            phase="encoding",
+            progress_quality=100.0,  # CRF search already done
+            crf=crf,
+            original_size=original_size,
+            total_duration_seconds=total_duration_seconds,
+            used_cached_crf=True,
         )
 
         # --- Starting Callback ---
@@ -1143,179 +764,63 @@ class AbAv1Wrapper:
             callback_info = {
                 "message": f"Encoding with cached CRF {format_crf(crf)}",
                 "crf": crf,
-                "original_size": stats.get("original_size"),
+                "original_size": original_size,
                 "used_cached_crf": True,
             }
             self.file_info_callback(os.path.basename(input_path), "starting", callback_info)
 
-        # --- Environment Setup ---
-        process_env = os.environ.copy()
-        # If vendor FFmpeg exists, prepend it to PATH so ab-av1 finds it
-        # This only affects this subprocess - user's system PATH is unchanged
-        if FFMPEG_DIR.exists():
-            process_env["PATH"] = str(FFMPEG_DIR) + os.pathsep + process_env.get("PATH", "")
-            logger.debug(f"Using vendor FFmpeg from {FFMPEG_DIR}")
-        process_env["RUST_LOG"] = "debug,ab_av1=trace,ffmpeg=trace"
-        process_env["AV1_PRINT_FFMPEG"] = "1"
-        process_env["AV1_RAW_OUTPUT"] = "1"
-
-        # --- Process Execution ---
-        process = None
-        return_code = -1
-        full_output_text = ""
-        current_output_lines: list[str] = []
-
-        try:
-            startupinfo, creationflags = get_windows_subprocess_startupinfo()
-
-            process = subprocess.Popen(
-                cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                universal_newlines=True,
-                bufsize=1,
-                cwd=output_dir,
-                startupinfo=startupinfo,
-                creationflags=creationflags,
-                encoding="utf-8",
-                errors="replace",
-                env=process_env,
-            )
-
-            if pid_callback:
-                pid_callback(process.pid)
-
-            logger.info(f"Encode process {process.pid} started. Reading output...")
-
-            assert process.stdout is not None  # noqa: S101 - Guaranteed by stdout=PIPE
-
-            for raw_line in iter(process.stdout.readline, ""):
-                line = raw_line.strip()
-                if not line:
-                    continue
-
-                if "sled::pagecache" in line:
-                    continue
-
-                current_output_lines.append(line + "\n")
-                stats = self.parser.parse_line(line, stats)
-
-            # Close stdout
-            try:
-                if process.stdout:
-                    process.stdout.close()
-            except Exception as e:
-                logger.warning(f"Error closing process stdout pipe: {e}")
-
-            # Get return code
-            final_poll_code = process.poll()
-            if final_poll_code is None:
-                logger.warning("Process is still running after pipe reading completed")
-                try:
-                    return_code = process.wait(timeout=30)
-                except subprocess.TimeoutExpired:
-                    logger.exception("Process did not complete, forcing termination")
-                    process.terminate()
-                    time.sleep(1)
-                    if process.poll() is None:
-                        process.kill()
-                    return_code = -1
-            else:
-                return_code = final_poll_code
-
-            logger.info(f"Encode process return code: {return_code}")
-            full_output_text = "".join(current_output_lines)
-
-        except FileNotFoundError as e:
-            error_msg = f"Executable not found: {self.executable_path}"
-            logger.exception(error_msg)
-            if self.file_info_callback:
-                self.file_info_callback(
-                    os.path.basename(input_path), "failed", {"message": error_msg, "type": "executable_not_found"}
-                )
-            raise FileNotFoundError(error_msg) from e
-
-        except Exception as e:
-            error_msg = f"Failed to run encode: {e}"
-            logger.exception(error_msg)
-
-            if self.file_info_callback:
-                self.file_info_callback(
-                    os.path.basename(input_path), "failed", {"message": error_msg, "type": "process_management_failed"}
-                )
-
-            if process and process.poll() is None:
-                try:
-                    process.terminate()
-                    time.sleep(0.2)
-                    process.kill()
-                except Exception as kill_e:
-                    logger.debug(f"Error terminating process: {kill_e}")
-
-            full_output_text = "".join(current_output_lines)
-            raise AbAv1Error(
-                error_msg, command=cmd_str, output=full_output_text, error_type="process_management_failed"
-            ) from e
+        result = self._run_once(
+            cmd,
+            input_path=input_path,
+            cwd=output_dir,
+            env=self._process_env(verbose_ffmpeg=True),
+            on_line=lambda line: self.parser.parse_line(line, stats),
+            cancel_event=cancel_event,
+            pid_callback=pid_callback,
+        )
 
         # --- Check Result ---
-        if return_code != 0:
-            error_msg = f"Encode failed with exit code {return_code}"
-            logger.error(error_msg)
-            logger.error(f"Output tail:\n{full_output_text[-1000:]}")
-
-            if self.file_info_callback:
-                self.file_info_callback(
-                    os.path.basename(input_path),
-                    "failed",
-                    {"message": error_msg, "type": "encoding_failed", "command": cmd_str_log},
-                )
-
-            clean_ab_av1_temp_folders(output_dir)
-            raise EncodingError(error_msg, command=cmd_str_log, output=full_output_text, error_type="encoding_failed")
+        if result.cancelled or result.silence_timeout or result.return_code != 0:
+            self._raise_for_failed_result(
+                result,
+                input_path=input_path,
+                cmd_str_log=cmd_str_log,
+                cleanup_dir=output_dir,
+                failure_error_type="encoding_failed",
+            )
 
         # --- Verify Output ---
-        if not os.path.exists(output_path):
-            error_msg = f"Encode reported success but output file is missing: {anonymized_output_path}"
-            logger.error(error_msg)
-            if self.file_info_callback:
-                self.file_info_callback(
-                    os.path.basename(input_path), "failed", {"message": error_msg, "type": "missing_output_on_success"}
-                )
-            raise OutputFileError(error_msg, command=cmd_str_log, error_type="missing_output_on_success")
+        self._verify_output_exists(output_path, input_path=input_path, cmd_str_log=cmd_str_log)
 
         # --- Success ---
         logger.info(f"Encode completed successfully for {anonymized_input_path} (CRF {format_crf(crf)})")
-        stats = self.parser.parse_final_output(full_output_text, stats)
-        stats["crf"] = crf  # Ensure CRF is set
+        self.parser.parse_final_output(result.output, stats)
+        stats.crf = crf  # Ensure CRF is set
 
         # Add timing (no CRF search - using cached CRF)
-        stats["crf_search_time_sec"] = 0  # Skipped CRF search
-        stats["encoding_time_sec"] = time.time() - encoding_start_time
+        stats.crf_search_time_sec = 0.0
+        stats.encoding_time_sec = time.time() - encoding_start_time
 
-        # Calculate actual size reduction
-        if stats.get("original_size"):
-            try:
-                output_size = os.path.getsize(output_path)
-                stats["output_size"] = output_size
-                stats["size_reduction"] = ((stats["original_size"] - output_size) / stats["original_size"]) * 100
-                logger.info(f"Actual size reduction: {stats['size_reduction']:.2f}%")
-            except Exception as e:
-                logger.warning(f"Could not calculate size reduction: {e}")
+        # Record output size and actual size reduction
+        try:
+            stats.output_size = os.path.getsize(output_path)
+            if original_size:
+                stats.size_reduction = ((original_size - stats.output_size) / original_size) * 100
+                logger.info(f"Actual size reduction: {stats.size_reduction:.2f}%")
+        except Exception as e:
+            logger.warning(f"Could not calculate size reduction: {e}")
 
         # --- Completion Callback ---
         if self.file_info_callback:
             final_stats_for_callback = {
                 "message": f"Complete (CRF {format_crf(crf)}, cached)",
                 "crf": crf,
-                "size_reduction": stats.get("size_reduction"),
+                "size_reduction": stats.size_reduction,
                 "output_path": output_path,
                 "used_cached_crf": True,
             }
-            try:
-                final_size = os.path.getsize(output_path)
-                final_stats_for_callback["output_size"] = final_size
-            except Exception as size_e:
-                logger.debug(f"Could not get final output size: {size_e}")
+            if stats.output_size is not None:
+                final_stats_for_callback["output_size"] = stats.output_size
 
             self.file_info_callback(os.path.basename(input_path), "completed", final_stats_for_callback)
 

--- a/src/config.py
+++ b/src/config.py
@@ -37,6 +37,18 @@ DEFAULT_ENCODING_PRESET = 6  # Corresponds to SVT-AV1 "--preset 6" (Balanced spe
 MIN_VMAF_FALLBACK_TARGET = 90  # Minimum VMAF target to attempt if initial target fails
 VMAF_FALLBACK_STEP = 1  # How much to decrement VMAF target on each fallback attempt
 
+# --- ab-av1 Process Management ---
+AB_AV1_OUTPUT_POLL_SEC = 1.0  # Read-loop wake interval for cancellation checks
+AB_AV1_SILENCE_TIMEOUT_SEC = 1800  # No output at debug verbosity for 30 min = hung process
+AB_AV1_EOF_WAIT_SEC = 30  # Post-EOF wait for process exit before terminating
+AB_AV1_TERMINATE_WAIT_SEC = 5  # Wait after terminate/kill before escalating
+TASKKILL_NOT_FOUND_RC = 128  # Windows taskkill exit code when the target process does not exist
+
+# ab-av1's message when no CRF meets the VMAF target (crate::Error::NoGoodCrf Display
+# impl). Matched case-insensitively as a substring so wording drift in future ab-av1
+# releases doesn't silently disable the VMAF fallback ladder.
+AB_AV1_NO_SUITABLE_CRF_MESSAGE = "Failed to find a suitable crf"
+
 # --- Progress Logging ---
 # Dynamic log interval tiers based on estimated duration (requires ab-av1 with --log-interval support)
 # Format: (max_duration_minutes, log_interval) - uses first matching tier

--- a/src/conversion_engine/worker.py
+++ b/src/conversion_engine/worker.py
@@ -14,7 +14,7 @@ import time
 from collections.abc import Callable  # Import Callable
 
 # Project imports
-from src.ab_av1.exceptions import ConversionNotWorthwhileError
+from src.ab_av1.exceptions import AbAv1CancelledError, ConversionNotWorthwhileError
 from src.ab_av1.wrapper import AbAv1Wrapper
 from src.cache_helpers import converted_verdict_applies, is_file_unchanged
 from src.config import DEFAULT_ENCODING_PRESET, DEFAULT_VMAF_TARGET, HISTORY_SAVE_INTERVAL_SEC, MIN_VMAF_FALLBACK_TARGET
@@ -268,6 +268,7 @@ def sequential_conversion_worker(
     gui,
     config: QueueConversionConfig,
     stop_event,
+    cancel_event,
     file_event_callback: Callable,
     queue_status_callback: Callable,
     reset_ui_callback: Callable,
@@ -284,7 +285,8 @@ def sequential_conversion_worker(
     Args:
         gui: The main GUI instance (passed for accessing settings, state, and root window).
         config: QueueConversionConfig containing queue items and conversion settings.
-        stop_event: Threading event to signal stopping.
+        stop_event: Threading event for graceful stop (finish current file, then stop).
+        cancel_event: Threading event set by force-stop; aborts the current ab-av1 run mid-process.
         file_event_callback: Callback for file conversion events (progress, errors, completion).
         queue_status_callback: Callback for updating queue tree (queue_item_id, status, processed, total).
         reset_ui_callback: Callback to reset UI details for a new file.
@@ -665,6 +667,14 @@ def sequential_conversion_worker(
 
                 # --- Process Video ---
                 process_successful = False
+                file_stopped = False  # Set when the current file's run is cancelled mid-process
+                file_decided = False  # Set when a verdict was already recorded (don't overwrite with STOPPED)
+
+                # Clear skip state left over from the previous file: it is set via
+                # root.after, so it can land after that file's post-processing already
+                # ran (synchronous clear is safe per the THREAD SAFETY NOTE above)
+                gui.session.last_skip_reason = None
+                gui.session.last_min_vmaf_attempted = None
                 output_file_path = None
                 elapsed_time_file = 0
                 output_size = 0
@@ -767,15 +777,16 @@ def sequential_conversion_worker(
                                 progress_callback=progress_cb,
                                 stop_event=stop_event,
                                 hw_decoder=hw_decoder,
+                                pid_callback=lambda pid, path=file_path: pid_storage_callback(gui, pid, path),
                             )
 
                             # Extract results from crf_search
-                            final_crf = crf_result.get("best_crf")
-                            final_vmaf = crf_result.get("best_vmaf")
-                            final_vmaf_target = crf_result.get("vmaf_target_used")
-                            predicted_output_size = crf_result.get("predicted_output_size")
-                            predicted_size_reduction = crf_result.get("predicted_size_reduction")
-                            crf_search_time = crf_result.get("crf_search_time_sec")
+                            final_crf = crf_result.best_crf
+                            final_vmaf = crf_result.best_vmaf
+                            final_vmaf_target = crf_result.vmaf_target_used
+                            predicted_output_size = crf_result.predicted_output_size
+                            predicted_size_reduction = crf_result.predicted_size_reduction
+                            crf_search_time = crf_result.crf_search_time_sec
 
                             # Update history index with Layer 2 data
                             record = _create_file_record(
@@ -824,6 +835,13 @@ def sequential_conversion_worker(
                                 gui.root, lambda fp=file_path: gui.update_analysis_tree_for_completed_file(fp, "done")
                             )
 
+                        except AbAv1CancelledError:
+                            # Stop request aborted the CRF search mid-run: the shared
+                            # stopped branch below records STOPPED and the count
+                            logger.info(f"Analysis cancelled for {anonymized_name}")
+                            file_stopped = True
+                            process_successful = False
+
                         except ConversionNotWorthwhileError as e:
                             # CRF search failed at all VMAF targets - record as NOT_WORTHWHILE
                             crf_search_elapsed = time.time() - crf_search_start
@@ -866,6 +884,7 @@ def sequential_conversion_worker(
                             )
 
                             process_successful = False
+                            file_decided = True
 
                     elif output_path is not None:
                         # CONVERT operation: Full conversion with process_video
@@ -880,6 +899,7 @@ def sequential_conversion_worker(
                             pid_callback=lambda pid, path=file_path: pid_storage_callback(gui, pid, path),
                             total_duration_seconds=input_duration,
                             hw_decoder=hw_decoder,
+                            cancel_event=cancel_event,
                         )
                         if result_tuple:
                             # Unpack tuple including timing breakdown
@@ -917,6 +937,7 @@ def sequential_conversion_worker(
                     error_msg = f"Internal processing error: {e!s}"
                     file_event_callback(filename, "failed", {"message": error_msg, "type": "processing_crash"})
                     process_successful = False
+                    file_decided = True  # ERROR recorded here; don't re-count in the post-processing chain
                     queue_item.files_failed += 1
                     queue_item.last_error = error_msg
                     _update_file_status(queue_item, file_index, QueueItemStatus.ERROR, error_msg)
@@ -990,7 +1011,13 @@ def sequential_conversion_worker(
                             )
                         except Exception:
                             logger.exception(f"Failed to record history for {anonymized_name}")
-                # Check if this was a NOT_WORTHWHILE skip and record to history
+                elif file_decided:
+                    # Verdict (e.g. ANALYZE NOT_WORTHWHILE) already recorded in the
+                    # operation branch - don't overwrite it with STOPPED or ERROR
+                    pass
+                # Check if this was a NOT_WORTHWHILE skip and record to history.
+                # A decided verdict outranks a concurrent force-stop: checked before
+                # the stopped branch so the history record isn't dropped.
                 elif gui.session.last_skip_reason:
                     queue_item.files_skipped += 1
                     _update_file_status(
@@ -1033,6 +1060,14 @@ def sequential_conversion_worker(
                         )
                     except Exception:
                         logger.exception(f"Failed to record NOT_WORTHWHILE history for {anonymized_name}")
+                elif file_stopped or cancel_event.is_set():
+                    # Force-stop (or ANALYZE stop) cancelled this file mid-run: stopped, not failed
+                    _update_file_status(queue_item, file_index, QueueItemStatus.STOPPED)
+
+                    def increment_stopped():
+                        gui.session.stopped_count += 1
+
+                    update_ui_safely(gui.root, increment_stopped)
                 else:
                     # process_video returned None due to error (not a NOT_WORTHWHILE skip)
                     # The error was already reported via callback, but we need to track it in queue item

--- a/src/gui/conversion_controller.py
+++ b/src/gui/conversion_controller.py
@@ -7,7 +7,6 @@ and GUI interaction layer for the conversion process.
 # Standard library imports
 import logging
 import os
-import signal
 import statistics
 import subprocess
 import sys
@@ -56,7 +55,12 @@ from src.gui.tree_display import QUEUE_STATUS_TAGS, format_queue_file_status
 from src.models import OutputMode, QueueConversionConfig, QueueItemStatus
 
 # Import from utils and other modules
-from src.platform_utils import allow_sleep_mode, get_windows_subprocess_startupinfo, prevent_sleep_mode
+from src.platform_utils import (
+    allow_sleep_mode,
+    get_windows_subprocess_startupinfo,
+    prevent_sleep_mode,
+    terminate_process_tree,
+)
 from src.privacy import anonymize_filename
 from src.utils import format_crf, format_file_size, format_time, update_ui_safely
 
@@ -346,6 +350,7 @@ def start_conversion(gui) -> None:
     gui.session.pending_files = []
     gui.session.current_file_path = None
     gui.stop_event = threading.Event()
+    gui.cancel_event = threading.Event()
 
     # Start timers
     def start_total_timer():
@@ -386,6 +391,7 @@ def start_conversion(gui) -> None:
             gui,
             config,
             gui.stop_event,
+            gui.cancel_event,
             file_callback,
             queue_callback,
             reset_ui_callback,
@@ -422,7 +428,7 @@ def stop_conversion(gui) -> None:
 
 
 def terminate_process(pid: int) -> bool:
-    """Terminate a process by PID, using platform-specific methods.
+    """Terminate a process tree by PID, with a kill-ffmpeg-by-name fallback.
 
     Args:
         pid: Process ID to terminate
@@ -435,54 +441,25 @@ def terminate_process(pid: int) -> bool:
         return False
 
     logger.info(f"Attempting to terminate process PID {pid}...")
-    try:
-        if sys.platform == "win32":
+    if terminate_process_tree(pid):
+        return True
+
+    # Fallback: try killing ffmpeg directly if the tree kill failed
+    if sys.platform == "win32":
+        try:
             startupinfo, _ = get_windows_subprocess_startupinfo()
-            result = subprocess.run(
-                ["taskkill", "/F", "/T", "/PID", str(pid)],
+            subprocess.run(
+                ["taskkill", "/F", "/IM", "ffmpeg.exe"],
                 capture_output=True,
                 text=True,
                 check=False,
                 startupinfo=startupinfo,
             )
-            if result.returncode == 0:
-                logger.info(f"Successfully terminated PID {pid} and its child processes via taskkill.")
-                return True
-            logger.warning(f"taskkill failed for PID {pid} (rc={result.returncode}): {result.stderr.strip()}")
-            # Fallback: try killing ffmpeg directly if taskkill failed
-            try:
-                subprocess.run(
-                    ["taskkill", "/F", "/IM", "ffmpeg.exe"],
-                    capture_output=True,
-                    text=True,
-                    check=False,
-                    startupinfo=startupinfo,
-                )
-                logger.info("Attempted fallback kill of ffmpeg.exe processes.")
-                return True
-            except Exception:
-                logger.exception("Failed fallback kill of ffmpeg processes")
-                return False
-        else:  # Linux/macOS
-            # Try SIGTERM first, then SIGKILL
-            os.kill(pid, signal.SIGTERM)
-            time.sleep(0.5)
-            try:
-                os.kill(pid, 0)  # Check if process still exists
-                # If it exists, SIGTERM failed, use SIGKILL
-                logger.warning(f"Process {pid} still alive after SIGTERM, sending SIGKILL.")
-                os.kill(pid, signal.SIGKILL)
-                logger.info(f"Sent SIGKILL to PID {pid}.")
-                return True
-            except ProcessLookupError:
-                logger.info(f"Process {pid} terminated successfully with SIGTERM.")
-                return True
-    except ProcessLookupError:
-        logger.warning(f"Process PID {pid} not found during termination attempt.")
-        return True  # Process already gone
-    except Exception:
-        logger.exception(f"Failed to terminate process PID {pid}")
-        return False
+            logger.info("Attempted fallback kill of ffmpeg.exe processes.")
+            return True
+        except Exception:
+            logger.exception("Failed fallback kill of ffmpeg processes")
+    return False
 
 
 def cleanup_temp_file(input_path: str, output_folder: str, input_folder: str) -> None:
@@ -572,6 +549,10 @@ def force_stop_conversion(gui, confirm: bool = True) -> None:
     gui.status_label.config(text="Force stopping...")
     if gui.stop_event:
         gui.stop_event.set()
+    if gui.cancel_event:
+        # In-band cancellation: the runner's read loop terminates the ab-av1
+        # process tree itself; the PID kill below remains as a backstop.
+        gui.cancel_event.set()
 
     # Get process information
     pid_to_kill = None
@@ -822,6 +803,7 @@ def conversion_complete(gui, final_message="Queue complete"):
     s.running = False
     gui.conversion_thread = None
     gui.stop_event = None
+    gui.cancel_event = None
     s.current_process_info = None
     s.current_file_path = None
     if s.elapsed_timer_id:  # Ensure timer is stopped if still running

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -168,6 +168,7 @@ class VideoConverterGUI:
         # Thread/Event primitives stay on self, not in session dataclass
         self.conversion_thread: threading.Thread | None = None
         self.stop_event: threading.Event | None = None
+        self.cancel_event: threading.Event | None = None
 
         # Initialize tk variables based on loaded config (needed *before* logging setup uses them)
         self.initialize_variables()
@@ -453,6 +454,7 @@ class VideoConverterGUI:
         # Thread primitives stay on self
         self.conversion_thread = None
         self.stop_event = threading.Event()
+        self.cancel_event = threading.Event()
 
     def initialize_button_states(self):
         """Initialize button states. Called after create_main_tab() creates buttons."""
@@ -488,6 +490,9 @@ class VideoConverterGUI:
         if self.stop_event:
             self.stop_event.set()
             logger.debug("Stop event set.")
+        if self.cancel_event:
+            self.cancel_event.set()
+            logger.debug("Cancel event set.")
         if self.conversion_thread and self.conversion_thread.is_alive():
             try:
                 logger.info("Waiting briefly for thread...")

--- a/src/platform_utils.py
+++ b/src/platform_utils.py
@@ -3,9 +3,14 @@
 
 import ctypes
 import logging
+import os
+import signal
 import subprocess
 import sys
+import time
 from typing import Any
+
+from src.config import TASKKILL_NOT_FOUND_RC
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +31,63 @@ def get_windows_subprocess_startupinfo() -> tuple[Any, int]:
     startupinfo.wShowWindow = subprocess.SW_HIDE
     creationflags = subprocess.CREATE_NO_WINDOW
     return startupinfo, creationflags
+
+
+def terminate_process_tree(pid: int) -> bool:
+    """Forcefully terminate a process and its whole child tree.
+
+    On Windows uses ``taskkill /F /T`` so ab-av1's ffmpeg children die with it.
+    On POSIX signals the process *group* (SIGTERM, escalating to SIGKILL) -
+    the runner spawns ab-av1 as a session leader so its group covers ffmpeg
+    children even when they are hung and cannot forward signals.
+
+    Returns:
+        True if the process is gone (or was already gone), False on error.
+    """
+    if sys.platform == "win32":
+        try:
+            startupinfo, creationflags = get_windows_subprocess_startupinfo()
+            result = subprocess.run(
+                ["taskkill", "/F", "/T", "/PID", str(pid)],
+                capture_output=True,
+                text=True,
+                check=False,
+                startupinfo=startupinfo,
+                creationflags=creationflags,
+            )
+            if result.returncode == 0:
+                logger.info(f"Terminated PID {pid} and its child processes via taskkill.")
+                return True
+            if result.returncode == TASKKILL_NOT_FOUND_RC:
+                logger.info(f"Process PID {pid} not found during termination attempt (already gone).")
+                return True
+            logger.warning(f"taskkill failed for PID {pid} (rc={result.returncode}): {result.stderr.strip()}")
+            return False
+        except Exception:
+            logger.exception(f"Failed to terminate process tree for PID {pid}")
+            return False
+
+    try:
+        # SIGKILL cannot be forwarded by ab-av1, so signal the whole group -
+        # otherwise a hung ffmpeg child survives the very kill that the
+        # silence-timeout path exists for.
+        pgid = os.getpgid(pid)
+        os.killpg(pgid, signal.SIGTERM)
+        time.sleep(0.5)
+        try:
+            os.kill(pid, 0)  # Check if process still exists
+        except ProcessLookupError:
+            logger.info(f"Process group {pgid} terminated successfully with SIGTERM.")
+            return True
+        logger.warning(f"Process {pid} still alive after SIGTERM, sending SIGKILL to group {pgid}.")
+        os.killpg(pgid, signal.SIGKILL)
+        return True
+    except ProcessLookupError:
+        logger.info(f"Process PID {pid} not found during termination attempt (already gone).")
+        return True
+    except Exception:
+        logger.exception(f"Failed to terminate process PID {pid}")
+        return False
 
 
 # --- Power Management Functions ---

--- a/src/video_conversion.py
+++ b/src/video_conversion.py
@@ -13,15 +13,12 @@ from pathlib import Path
 from typing import Any
 
 from src.ab_av1.exceptions import (
+    AbAv1CancelledError,
     AbAv1Error,
     ConversionNotWorthwhileError,
-    EncodingError,
     InputFileError,
     OutputFileError,
-    VMAFError,
 )
-
-# Corrected import path: Use src.ab_av1 instead of src.ab_av1_wrapper
 from src.ab_av1.wrapper import AbAv1Wrapper
 
 # Import constants from config
@@ -128,7 +125,8 @@ def process_video(
     pid_callback: Callable[..., Any] | None = None,
     total_duration_seconds: float = 0.0,
     hw_decoder: str | None = None,
-) -> tuple[str, float, int, int, int | None, float | None, int | None, float, float] | None:
+    cancel_event: Any | None = None,
+) -> tuple[str, float, int, int, float | None, float | None, int | None, float, float] | None:
     """
     Process a single video file using ab-av1 with hardcoded quality settings.
 
@@ -143,6 +141,7 @@ def process_video(
         pid_callback: Optional callback for receiving process ID
         total_duration_seconds: Total duration of the input video in seconds (for progress calc)
         hw_decoder: Optional hardware decoder name (e.g., "h264_cuvid", "hevc_qsv")
+        cancel_event: Optional threading.Event; set by force-stop to abort mid-encode
 
     Returns:
         tuple: (output_path, elapsed_time, input_size, output_size, final_crf, final_vmaf,
@@ -265,6 +264,7 @@ def process_video(
                 pid_callback=pid_callback,
                 total_duration_seconds=total_duration_seconds,
                 hw_decoder=hw_decoder,
+                cancel_event=cancel_event,
             )
         else:
             # No cache - run full auto-encode with CRF search
@@ -276,6 +276,7 @@ def process_video(
                 pid_callback=pid_callback,
                 total_duration_seconds=total_duration_seconds,
                 hw_decoder=hw_decoder,
+                cancel_event=cancel_event,
             )
 
         conversion_elapsed_time = time.time() - conversion_start_time
@@ -298,12 +299,12 @@ def process_video(
 
         log_conversion_result(str(input_path), str(output_path_obj), conversion_elapsed_time)
 
-        final_vmaf = result_stats.get("vmaf") if result_stats else None
-        final_crf = result_stats.get("crf") if result_stats else None
+        final_vmaf = result_stats.vmaf
+        final_crf = result_stats.crf
         if use_cached_crf and record and record.vmaf_target_when_analyzed is not None:
             final_vmaf_target = record.vmaf_target_when_analyzed
         else:
-            final_vmaf_target = result_stats.get("vmaf_target_used") if result_stats else DEFAULT_VMAF_TARGET
+            final_vmaf_target = result_stats.vmaf_target_used
         logger.info(
             f"Conversion successful - Final VMAF: {final_vmaf if final_vmaf else 'N/A'}, "
             f"Final CRF: {format_crf(final_crf) if final_crf is not None else 'N/A'} "
@@ -331,8 +332,8 @@ def process_video(
                 # Don't fail the conversion if we can't delete the original
 
         # Extract timing breakdown from result_stats
-        crf_search_time = result_stats.get("crf_search_time_sec", 0) if result_stats else 0
-        encoding_time = result_stats.get("encoding_time_sec", 0) if result_stats else conversion_elapsed_time
+        crf_search_time = result_stats.crf_search_time_sec
+        encoding_time = result_stats.encoding_time_sec
 
         # Return success tuple including stats for history
         return (
@@ -347,12 +348,16 @@ def process_video(
             encoding_time,
         )
 
+    except AbAv1CancelledError:
+        # Force-stop cancelled the run mid-encode; the worker marks the file STOPPED
+        logger.info(f"Conversion cancelled for {anonymized_input_name}")
+        return None
     except ConversionNotWorthwhileError as e:
         # Note: The wrapper already called the file_info_callback with "skipped_not_worth"
         # before raising this exception, so we don't call it again here to avoid double-counting
         logger.info(f"Conversion not worthwhile for {anonymized_input_name}: {e}")
         return None  # Return None like other skipped files, not an error
-    except (InputFileError, OutputFileError, VMAFError, EncodingError, AbAv1Error):
+    except (InputFileError, OutputFileError, AbAv1Error):
         # Note: The wrapper already called the file_info_callback with "failed" status
         # before raising these exceptions, so we don't call it again here to avoid double-counting
         logger.exception(f"Conversion failed for {anonymized_input_name}")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,11 +2,14 @@
 """Characterization tests for AbAv1Parser.parse_line (src/ab_av1/parser.py).
 
 Lines are modeled on real ab-av1/ffmpeg output as documented in
-docs/AB_AV1_PARSING.md. The stats dict is seeded the same way
+docs/AB_AV1_PARSING.md. EncodeStats is seeded the same way
 AbAv1Wrapper.auto_encode() seeds it (src/ab_av1/wrapper.py).
 """
 
+from dataclasses import replace
+
 from src.ab_av1.parser import AbAv1Parser
+from src.ab_av1.stats import EncodeStats
 
 
 class CallbackRecorder:
@@ -23,32 +26,24 @@ class CallbackRecorder:
         return [info for _, _, info in self.calls]
 
 
-def make_stats(input_path: str = "/videos/movie.mp4", total_duration_seconds: float | None = 600.0) -> dict:
-    """Seed a stats dict the way AbAv1Wrapper.auto_encode() does."""
-    return {
-        "phase": "crf-search",
-        "progress_quality": 0,
-        "progress_encoding": 0,
-        "vmaf": None,
-        "crf": None,
-        "size_reduction": None,
-        "input_path": input_path,
-        "output_path": "/videos/movie.mkv",
-        "command": "",
-        "vmaf_target_used": 95,
-        "last_ffmpeg_fps": None,
-        "eta_text": None,
-        "total_duration_seconds": total_duration_seconds,
-        "last_reported_encoding_progress": -1.0,
-        "estimated_output_size": None,
-        "estimated_size_reduction": None,
-    }
+def make_stats(input_path: str = "/videos/movie.mp4", total_duration_seconds: float | None = 600.0) -> EncodeStats:
+    """Seed stats the way AbAv1Wrapper.auto_encode() does."""
+    return EncodeStats(
+        input_path=input_path,
+        output_path="/videos/movie.mkv",
+        vmaf_target_used=95,
+        total_duration_seconds=total_duration_seconds,
+    )
 
 
-def make_encoding_stats(**kwargs) -> dict:
-    """Stats dict as it looks after the parser's phase transition to encoding."""
+def make_encoding_stats(**kwargs) -> EncodeStats:
+    """Stats as they look after the parser's phase transition to encoding."""
     stats = make_stats(**kwargs)
-    stats.update({"phase": "encoding", "progress_quality": 100.0, "progress_encoding": 0.0, "crf": 30, "vmaf": 95.5})
+    stats.phase = "encoding"
+    stats.progress_quality = 100.0
+    stats.progress_encoding = 0.0
+    stats.crf = 30
+    stats.vmaf = 95.5
     return stats
 
 
@@ -68,9 +63,9 @@ def test_crf_vmaf_line_updates_stats_and_fires_progress_callback():
 
     parser.parse_line("crf 30 VMAF 96.50 (23%)", stats)
 
-    assert stats["crf"] == 30
-    assert stats["vmaf"] == 96.5
-    assert stats["progress_quality"] == 10.0
+    assert stats.crf == 30
+    assert stats.vmaf == 96.5
+    assert stats.progress_quality == 10.0
     assert len(recorder.calls) == 1
     filename, status, event = recorder.calls[0]
     assert filename == "movie.mp4"  # raw basename of input_path, kept raw for GUI display
@@ -88,7 +83,7 @@ def test_repeated_crf_vmaf_lines_cap_quality_progress_at_90():
     for i in range(12):
         parser.parse_line(f"crf {30 + i} VMAF 9{i % 10}.00", stats)
 
-    assert stats["progress_quality"] == 90.0
+    assert stats.progress_quality == 90.0
     # Callbacks only fire while progress increases: 10 -> 90 in 10% steps.
     assert len(recorder.calls) == 9
 
@@ -99,8 +94,8 @@ def test_best_crf_line_sets_crf_and_95_percent_quality():
 
     parser.parse_line("Best CRF: 31", stats)
 
-    assert stats["crf"] == 31
-    assert stats["progress_quality"] == 95.0
+    assert stats.crf == 31
+    assert stats.progress_quality == 95.0
     assert len(recorder.calls) == 1
     assert recorder.events[0].crf == 31
 
@@ -112,8 +107,8 @@ def test_fractional_crf_vmaf_line_parses_quarter_step_value():
 
     parser.parse_line("crf 23.25 VMAF 96.50 (34%)", stats)
 
-    assert stats["crf"] == 23.25
-    assert stats["vmaf"] == 96.5
+    assert stats.crf == 23.25
+    assert stats.vmaf == 96.5
     assert len(recorder.calls) == 1
     assert recorder.events[0].message == "Detecting Quality (CRF:23.25, VMAF:96.5)"
 
@@ -125,8 +120,8 @@ def test_fractional_sample_log_line_parses_crf_and_vmaf():
 
     parser.parse_line("sample 3/5 crf 23.25 VMAF 95.11 (9%)", stats)
 
-    assert stats["crf"] == 23.25
-    assert stats["vmaf"] == 95.11
+    assert stats.crf == 23.25
+    assert stats.vmaf == 95.11
 
 
 def test_fractional_best_crf_line_is_not_truncated():
@@ -135,8 +130,8 @@ def test_fractional_best_crf_line_is_not_truncated():
 
     parser.parse_line("Best CRF: 23.25", stats)
 
-    assert stats["crf"] == 23.25
-    assert stats["progress_quality"] == 95.0
+    assert stats.crf == 23.25
+    assert stats.progress_quality == 95.0
     assert recorder.events[0].crf == 23.25
 
 
@@ -147,7 +142,7 @@ def test_predicted_size_reduction_line_stores_reduction_without_callback():
     parser.parse_line("predicted video stream size 450MB (65%)", stats)
 
     # Line reports predicted size as 65% of original => 35% reduction.
-    assert stats["size_reduction"] == 35.0
+    assert stats.size_reduction == 35.0
     # Quality progress did not increase, so no callback fires.
     assert recorder.calls == []
 
@@ -155,7 +150,7 @@ def test_predicted_size_reduction_line_stores_reduction_without_callback():
 def test_unrelated_line_in_crf_search_changes_nothing():
     parser, recorder = make_parser()
     stats = make_stats()
-    before = dict(stats)
+    before = replace(stats)
 
     result = parser.parse_line("Svt[info]: SVT [version]: SVT-AV1 Encoder Lib v2.1.0", stats)
 
@@ -166,7 +161,7 @@ def test_unrelated_line_in_crf_search_changes_nothing():
 def test_empty_line_returns_stats_unchanged():
     parser, recorder = make_parser()
     stats = make_stats()
-    before = dict(stats)
+    before = replace(stats)
 
     result = parser.parse_line("   ", stats)
 
@@ -183,13 +178,15 @@ def test_empty_line_returns_stats_unchanged():
 def test_encode_log_line_triggers_phase_transition():
     parser, recorder = make_parser()
     stats = make_stats()
-    stats.update({"progress_quality": 95.0, "crf": 31, "vmaf": 95.1})
+    stats.progress_quality = 95.0
+    stats.crf = 31
+    stats.vmaf = 95.1
 
     parser.parse_line("[2024-01-01T00:00:00Z INFO ab_av1::command::encode] encoding video.mkv", stats)
 
-    assert stats["phase"] == "encoding"
-    assert stats["progress_quality"] == 100.0
-    assert stats["progress_encoding"] == 0.0
+    assert stats.phase == "encoding"
+    assert stats.progress_quality == 100.0
+    assert stats.progress_encoding == 0.0
     assert len(recorder.calls) == 1
     event = recorder.events[0]
     assert event.message == "Encoding started"
@@ -204,7 +201,7 @@ def test_starting_encoding_text_also_triggers_transition():
 
     parser.parse_line("Starting encoding", stats)
 
-    assert stats["phase"] == "encoding"
+    assert stats.phase == "encoding"
 
 
 def test_encode_log_line_ignored_when_already_encoding():
@@ -213,7 +210,7 @@ def test_encode_log_line_ignored_when_already_encoding():
 
     parser.parse_line("[2024-01-01T00:00:00Z INFO ab_av1::command::encode] encoding video.mkv", stats)
 
-    assert stats["phase"] == "encoding"
+    assert stats.phase == "encoding"
     assert recorder.calls == []
 
 
@@ -228,9 +225,9 @@ def test_sample_encode_progress_line():
 
     parser.parse_line("[2024-01-01T00:00:00Z INFO ab_av1::command::sample_encode] 45.2%, 30 fps, eta 5m 30s", stats)
 
-    assert stats["progress_encoding"] == 45.2
-    assert stats["last_ffmpeg_fps"] == 30
-    assert stats["eta_text"] == "5m 30s"
+    assert stats.progress_encoding == 45.2
+    assert stats.last_ffmpeg_fps == 30
+    assert stats.eta_text == "5m 30s"
     assert len(recorder.calls) == 1
     event = recorder.events[0]
     assert event.message == "Encoding: 45.2% (FPS: 30, ETA: 5m 30s)"
@@ -244,9 +241,9 @@ def test_main_encode_progress_line():
 
     parser.parse_line("[2024-01-01T00:00:00Z INFO ab_av1::command::encode] 45%, 30 fps, eta 5m 30s", stats)
 
-    assert stats["progress_encoding"] == 45.0
-    assert stats["last_ffmpeg_fps"] == 30
-    assert stats["eta_text"] == "5m 30s"
+    assert stats.progress_encoding == 45.0
+    assert stats.last_ffmpeg_fps == 30
+    assert stats.eta_text == "5m 30s"
     assert len(recorder.calls) == 1
     assert recorder.events[0].message == "Encoding: 45.0% (FPS: 30, ETA: 5m 30s)"
 
@@ -265,8 +262,8 @@ def test_ffmpeg_time_line_computes_progress_from_duration():
     parser.parse_line(FFMPEG_LINE, stats)
 
     # 300s of 600s => 50%
-    assert stats["progress_encoding"] == 50.0
-    assert stats["last_ffmpeg_fps"] == 25.0
+    assert stats.progress_encoding == 50.0
+    assert stats.last_ffmpeg_fps == 25.0
     assert len(recorder.calls) == 1
     event = recorder.events[0]
     assert event.message == "Encoding: 50.0% (25 fps, 1.25x)"
@@ -280,7 +277,7 @@ def test_ffmpeg_time_line_throttles_repeat_updates():
     parser.parse_line(FFMPEG_LINE, stats)
     parser.parse_line(FFMPEG_LINE, stats)  # same timestamp: < 0.1% increase
 
-    assert stats["progress_encoding"] == 50.0
+    assert stats.progress_encoding == 50.0
     assert len(recorder.calls) == 1
 
 
@@ -290,7 +287,7 @@ def test_ffmpeg_time_line_without_duration_is_ignored():
 
     parser.parse_line(FFMPEG_LINE, stats)
 
-    assert stats["progress_encoding"] == 0.0
+    assert stats.progress_encoding == 0.0
     assert recorder.calls == []
 
 
@@ -300,7 +297,7 @@ def test_ffmpeg_progress_never_exceeds_99_9():
 
     parser.parse_line("frame= 100 fps= 25.0 time=00:02:00.00 speed=1.0x", stats)
 
-    assert stats["progress_encoding"] == 99.9
+    assert stats.progress_encoding == 99.9
 
 
 # ---------------------------------------------------------------------------
@@ -314,7 +311,7 @@ def test_generic_percentage_fallback():
 
     parser.parse_line("progress: 62%", stats)
 
-    assert stats["progress_encoding"] == 62.0
+    assert stats.progress_encoding == 62.0
     assert len(recorder.calls) == 1
     assert recorder.events[0].message == "Encoding: 62.0%"
 
@@ -325,23 +322,23 @@ def test_generic_percentage_fallback_never_regresses_progress():
     # the progress bar backwards.
     parser, recorder = make_parser()
     stats = make_encoding_stats()
-    stats["progress_encoding"] = 80.0
+    stats.progress_encoding = 80.0
 
     parser.parse_line("some tool output mentioning 10%", stats)
 
-    assert stats["progress_encoding"] == 80.0
+    assert stats.progress_encoding == 80.0
     assert recorder.calls == []
 
 
 def test_ab_av1_summary_line_updates_eta_only():
     parser, recorder = make_parser()
     stats = make_encoding_stats()
-    stats["progress_encoding"] = 42.0
+    stats.progress_encoding = 42.0
 
     parser.parse_line("00:00:37 Encoding -------- (encoding, eta 36m)", stats)
 
-    assert stats["eta_text"] == "36m"
-    assert stats["progress_encoding"] == 42.0  # percentage untouched
+    assert stats.eta_text == "36m"
+    assert stats.progress_encoding == 42.0  # percentage untouched
     assert len(recorder.calls) == 1
     assert recorder.events[0].message == "Encoding: 42.0% (ETA: 36m)"
 
@@ -353,7 +350,7 @@ def test_ab_av1_summary_line_updates_eta_only():
 def test_unrelated_line_in_encoding_phase_changes_nothing():
     parser, recorder = make_parser()
     stats = make_encoding_stats()
-    before = dict(stats)
+    before = replace(stats)
 
     parser.parse_line("Svt[info]: Number of logical cores available: 16", stats)
 
@@ -368,8 +365,8 @@ def test_parse_line_without_callback_does_not_raise():
     parser.parse_line("crf 30 VMAF 96.50", stats)
     parser.parse_line("Best CRF: 30", stats)
 
-    assert stats["crf"] == 30
-    assert stats["progress_quality"] == 95.0
+    assert stats.crf == 30
+    assert stats.progress_quality == 95.0
 
 
 def test_parse_final_output_keeps_fractional_crf():
@@ -378,5 +375,5 @@ def test_parse_final_output_keeps_fractional_crf():
 
     parser.parse_final_output("Best CRF: 23.25\nVMAF 95.32\n", stats)
 
-    assert stats["crf"] == 23.25
-    assert stats["vmaf"] == 95.32
+    assert stats.crf == 23.25
+    assert stats.vmaf == 95.32

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,303 @@
+# tests/test_runner.py
+"""Tests for run_ab_av1 (src/ab_av1/runner.py).
+
+A FakeProcess stands in for subprocess.Popen: readline yields scripted lines
+then EOFs or blocks, wait() honours an "exited" flag, and terminate_process_tree
+is monkeypatched to record calls and (optionally) kill the fake. Timeouts are
+shrunk so every path resolves in milliseconds.
+"""
+
+import subprocess
+import threading
+
+import pytest
+import src.ab_av1.runner as runner_mod
+from src.ab_av1.runner import run_ab_av1
+
+FAST = {"silence_timeout_sec": 5.0, "poll_interval_sec": 0.01, "eof_wait_sec": 1.0, "terminate_wait_sec": 1.0}
+
+
+class FakeProcess:
+    """Scripted stand-in for subprocess.Popen with a merged stdout pipe."""
+
+    def __init__(self, lines, rc=0, exits_after_eof=True, block_after_lines=False):
+        self.pid = 4242
+        self.returncode = None
+        self.stdout = self
+        self.kill_called = False
+        self.wait_calls = 0
+        self._rc = rc
+        self._lines = list(lines)
+        self._block = block_after_lines
+        self._unblock = threading.Event()
+        self._exited = threading.Event()
+        if exits_after_eof and not block_after_lines:
+            self._exited.set()
+
+    # --- file-object interface (used via process.stdout) ---
+
+    def readline(self):
+        if self._lines:
+            return self._lines.pop(0)
+        if self._block:
+            self._unblock.wait()
+        return ""
+
+    def close(self):
+        pass
+
+    # --- process interface ---
+
+    def poll(self):
+        return self.returncode
+
+    def wait(self, timeout=None):
+        self.wait_calls += 1
+        if not self._exited.is_set():
+            raise subprocess.TimeoutExpired("ab-av1", timeout or 0)
+        self.returncode = self._rc
+        return self.returncode
+
+    def kill(self):
+        self.kill_called = True
+        self.die(rc=-9)
+
+    def die(self, rc):
+        """Simulate the process dying: unblock readline, let wait() return."""
+        if self.returncode is None:
+            self._rc = rc
+        self._exited.set()
+        self._unblock.set()
+
+
+@pytest.fixture
+def install(monkeypatch):
+    """Install a FakeProcess as the runner's Popen; record tree-kill calls."""
+
+    def _install(fake, kill_on_terminate=True):
+        state = {"fake": fake, "tree_kills": []}
+
+        def fake_popen(cmd, **kwargs):
+            state["cmd"] = cmd
+            return fake
+
+        def fake_tree_kill(pid):
+            state["tree_kills"].append(pid)
+            if kill_on_terminate:
+                fake.die(rc=-15)
+            return True
+
+        monkeypatch.setattr(runner_mod.subprocess, "Popen", fake_popen)
+        monkeypatch.setattr(runner_mod, "terminate_process_tree", fake_tree_kill)
+        return state
+
+    return _install
+
+
+def test_clean_run_filters_noise_and_reports_rc(install):
+    fake = FakeProcess(["line one\n", "   \n", "[TRACE sled::pagecache] internal noise\n", "line two\n"], rc=0)
+    state = install(fake)
+    seen = []
+    pids = []
+
+    result = run_ab_av1(["ab-av1"], cwd=".", env={}, on_line=seen.append, pid_callback=pids.append, **FAST)
+
+    assert result.return_code == 0
+    assert seen == ["line one", "line two"]
+    assert result.output == "line one\nline two"
+    assert result.error_line is None
+    assert result.cancelled is False
+    assert result.silence_timeout is False
+    assert pids == [4242]
+    assert state["tree_kills"] == []
+
+
+def test_on_line_exception_does_not_abort_run(install):
+    fake = FakeProcess(["good\n", "boom\n", "after\n"], rc=0)
+    install(fake)
+    seen = []
+
+    def on_line(line):
+        seen.append(line)
+        if line == "boom":
+            raise ValueError("callback bug")
+
+    result = run_ab_av1(["ab-av1"], cwd=".", env={}, on_line=on_line, **FAST)
+
+    assert result.return_code == 0
+    assert seen == ["good", "boom", "after"]
+    assert result.output == "good\nboom\nafter"
+
+
+def test_cancel_mid_stream_terminates_and_reaps(install):
+    fake = FakeProcess([f"line {i}\n" for i in range(1, 6)], exits_after_eof=False, block_after_lines=True)
+    state = install(fake)
+    cancel = threading.Event()
+    seen = []
+
+    def on_line(line):
+        seen.append(line)
+        if len(seen) == 3:
+            cancel.set()
+
+    result = run_ab_av1(["ab-av1"], cwd=".", env={}, on_line=on_line, cancel_event=cancel, **FAST)
+
+    assert result.cancelled is True
+    assert result.silence_timeout is False
+    assert seen == ["line 1", "line 2", "line 3"]
+    assert state["tree_kills"] == [4242]
+    assert fake.wait_calls >= 1
+    assert fake.returncode is not None  # reaped
+
+
+def test_cancel_during_silence_wakes_on_poll_interval(install):
+    fake = FakeProcess([], exits_after_eof=False, block_after_lines=True)
+    state = install(fake)
+    cancel = threading.Event()
+    cancel.set()
+
+    result = run_ab_av1(["ab-av1"], cwd=".", env={}, cancel_event=cancel, **FAST)
+
+    assert result.cancelled is True
+    assert state["tree_kills"] == [4242]
+    assert fake.returncode is not None
+
+
+def test_silent_hung_process_hits_silence_timeout(install):
+    fake = FakeProcess([], exits_after_eof=False, block_after_lines=True)
+    state = install(fake)
+
+    result = run_ab_av1(
+        ["ab-av1"],
+        cwd=".",
+        env={},
+        silence_timeout_sec=0.05,
+        poll_interval_sec=0.01,
+        eof_wait_sec=1.0,
+        terminate_wait_sec=1.0,
+    )
+
+    assert result.silence_timeout is True
+    assert result.cancelled is False
+    assert state["tree_kills"] == [4242]
+    assert fake.returncode is not None
+
+
+def test_last_error_line_is_extracted(install):
+    fake = FakeProcess(
+        [
+            "[2026-01-01T00:00:00Z DEBUG ab_av1] some log\n",
+            "Error: something transient\n",
+            "Error: Failed to find a suitable crf\n",
+        ],
+        rc=1,
+    )
+    install(fake)
+
+    result = run_ab_av1(["ab-av1"], cwd=".", env={}, **FAST)
+
+    assert result.return_code == 1
+    assert result.error_line == "Failed to find a suitable crf"
+
+
+def test_kill_escalation_when_tree_kill_does_not_work(install):
+    fake = FakeProcess([], exits_after_eof=False, block_after_lines=True)
+    state = install(fake, kill_on_terminate=False)
+    cancel = threading.Event()
+    cancel.set()
+
+    result = run_ab_av1(
+        ["ab-av1"],
+        cwd=".",
+        env={},
+        cancel_event=cancel,
+        silence_timeout_sec=5.0,
+        poll_interval_sec=0.01,
+        eof_wait_sec=1.0,
+        terminate_wait_sec=0.01,
+    )
+
+    assert result.cancelled is True
+    assert state["tree_kills"] == [4242]
+    assert fake.kill_called is True
+    assert fake.returncode is not None  # reaped after kill()
+
+
+def test_out_of_band_kill_with_cancel_set_reports_cancelled(install):
+    # Force-stop backstop race: an external PID kill closes the pipe (EOF) before
+    # the poll loop ever sees cancel_event. The nonzero rc must still be reported
+    # as a cancellation, not a failure.
+    fake = FakeProcess([], rc=-15)
+    state = install(fake)
+    cancel = threading.Event()
+    cancel.set()
+
+    # Large poll interval: the loop can only wake via the reader's EOF sentinel,
+    # guaranteeing we exercise the EOF path rather than the poll-tick cancel check.
+    result = run_ab_av1(
+        ["ab-av1"],
+        cwd=".",
+        env={},
+        cancel_event=cancel,
+        silence_timeout_sec=30.0,
+        poll_interval_sec=30.0,
+        eof_wait_sec=1.0,
+        terminate_wait_sec=1.0,
+    )
+
+    assert result.cancelled is True
+    assert result.return_code == -15
+    assert state["tree_kills"] == []  # killed out-of-band, not by the runner
+
+
+def test_clean_exit_with_cancel_set_is_not_cancelled(install):
+    # A genuine rc=0 success races a late cancel: the completed work wins.
+    fake = FakeProcess([], rc=0)
+    install(fake)
+    cancel = threading.Event()
+    cancel.set()
+
+    result = run_ab_av1(
+        ["ab-av1"],
+        cwd=".",
+        env={},
+        cancel_event=cancel,
+        silence_timeout_sec=30.0,
+        poll_interval_sec=30.0,
+        eof_wait_sec=1.0,
+        terminate_wait_sec=1.0,
+    )
+
+    assert result.cancelled is False
+    assert result.return_code == 0
+
+
+def test_error_line_not_extracted_on_success(install):
+    fake = FakeProcess(["Error: transient warning that did not kill the run\n"], rc=0)
+    install(fake)
+
+    result = run_ab_av1(["ab-av1"], cwd=".", env={}, **FAST)
+
+    assert result.return_code == 0
+    assert result.error_line is None
+
+
+def test_eof_without_exit_terminates_after_wait(install):
+    fake = FakeProcess(["only line\n"], exits_after_eof=False)
+    state = install(fake)
+
+    result = run_ab_av1(
+        ["ab-av1"],
+        cwd=".",
+        env={},
+        silence_timeout_sec=5.0,
+        poll_interval_sec=0.01,
+        eof_wait_sec=0.01,
+        terminate_wait_sec=1.0,
+    )
+
+    assert result.cancelled is False
+    assert result.silence_timeout is False
+    assert state["tree_kills"] == [4242]
+    assert result.return_code == -15
+    assert result.output == "only line"

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,38 @@
+# tests/test_stats.py
+"""Tests for EncodeStats (src/ab_av1/stats.py)."""
+
+from src.ab_av1.stats import EncodeStats
+
+
+def test_reset_for_attempt_clears_per_attempt_state():
+    stats = EncodeStats(
+        phase="encoding",
+        progress_quality=80.0,
+        progress_encoding=45.0,
+        vmaf=93.4,
+        crf=27.0,
+        eta_text="5m",
+        last_ffmpeg_fps=120.0,
+        vmaf_target_used=95,
+    )
+
+    stats.reset_for_attempt(94)
+
+    assert stats.phase == "crf-search"
+    assert stats.progress_quality == 0.0
+    assert stats.progress_encoding == 0.0
+    assert stats.vmaf is None
+    assert stats.crf is None
+    assert stats.eta_text is None
+    assert stats.last_ffmpeg_fps is None
+    assert stats.vmaf_target_used == 94
+
+
+def test_reset_for_attempt_preserves_size_reduction():
+    # The prediction from an earlier attempt remains the best available estimate
+    # until the next attempt parses a new one.
+    stats = EncodeStats(size_reduction=42.5)
+
+    stats.reset_for_attempt(94)
+
+    assert stats.size_reduction == 42.5

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1,0 +1,52 @@
+# tests/test_wrapper.py
+"""Tests for the pure helpers in src/ab_av1/wrapper.py.
+
+_is_no_suitable_crf pins the VMAF-fallback trigger contract: it must tolerate
+wording drift (case, suffixes) in ab-av1's NoGoodCrf message, because ab-av1 is
+auto-updated and a silent mismatch would disable the entire fallback ladder.
+"""
+
+from src.ab_av1.runner import ProcessResult
+from src.ab_av1.wrapper import _format_cmd_for_log, _is_no_suitable_crf
+
+
+def _failed(error_line, output=""):
+    return ProcessResult(return_code=1, output=output, error_line=error_line)
+
+
+class TestIsNoSuitableCrf:
+    def test_exact_message_matches(self):
+        assert _is_no_suitable_crf(_failed("Failed to find a suitable crf")) is True
+
+    def test_suffixed_message_matches(self):
+        assert _is_no_suitable_crf(_failed("Failed to find a suitable crf, last crf 17 vmaf 94.2")) is True
+
+    def test_case_insensitive(self):
+        assert _is_no_suitable_crf(_failed("failed to find a suitable CRF")) is True
+
+    def test_falls_back_to_output_when_no_error_line(self):
+        result = _failed(None, output="[DEBUG ab_av1] ...\nFailed to find a suitable crf\n[TRACE] tail")
+        assert _is_no_suitable_crf(result) is True
+
+    def test_unrelated_failure_does_not_match(self):
+        assert _is_no_suitable_crf(_failed("Invalid data found when processing input")) is False
+
+    def test_no_error_line_and_unrelated_output_does_not_match(self):
+        assert _is_no_suitable_crf(_failed(None, output="ffmpeg exited with code 1")) is False
+
+
+class TestFormatCmdForLog:
+    def test_replaces_known_tokens_and_keeps_the_rest(self):
+        cmd = ["/vendor/ab-av1", "auto-encode", "-i", "/videos/movie.mp4", "-o", "/out/movie.mkv", "--preset", "6"]
+        replacements = {
+            "/vendor/ab-av1": "ab-av1",
+            "/videos/movie.mp4": "file_8a4b.mp4",
+            "/out/movie.mkv": "file_1a2b.mkv",
+        }
+        assert (
+            _format_cmd_for_log(cmd, replacements) == "ab-av1 auto-encode -i file_8a4b.mp4 -o file_1a2b.mkv --preset 6"
+        )
+
+    def test_no_replacements_returns_joined_cmd(self):
+        cmd = ["ab-av1", "crf-search", "--min-vmaf", "95"]
+        assert _format_cmd_for_log(cmd, {}) == "ab-av1 crf-search --min-vmaf 95"


### PR DESCRIPTION
Subprocess lifecycle (spawn, stream output, cancel, reap) moves out of `AbAv1Wrapper` into a new `ab_av1/runner.py`, and the result dataclasses into `ab_av1/stats.py`. The wrapper keeps high-level orchestration only: the three operations (auto-encode, crf-search, encode-with-crf) now share one input-validation path, one environment builder, one VMAF fallback loop, and one failure-to-exception translation instead of three drifting copies. `wrapper.py` drops from ~1900 to ~840 lines.

The runner uses a dedicated reader thread feeding a queue, so the main loop wakes on a poll interval even while ab-av1 is silent. That is what makes mid-run cancellation and hung-process detection (30 min silence timeout) work between output lines, replacing the old blocking `readline` loop.

Cancellation semantics are the part worth reviewing closely (`runner.py`, then the result handling in `wrapper.py`):

- If an out-of-band kill (the GUI force-stop backstop) closes the pipe before the poll loop observes `cancel_event`, the runner now latches `cancelled` on any non-zero exit with the event set, so a user stop is reported as STOPPED rather than a failure. A genuine rc=0 finish still counts as success.
- On POSIX the runner spawns ab-av1 as a session leader and `terminate_process_tree` kills the process group, so a hung ffmpeg child dies with it (SIGKILL cannot be forwarded by ab-av1).
- The worker's post-processing now lets a decided verdict (for example NOT_WORTHWHILE) outrank a concurrent force-stop, records STOPPED bookkeeping exactly once for both operation types, and clears stale skip state per file. Previously an ANALYZE not-worthwhile verdict could race the callback and be recorded as ERROR.

Two behavior changes beyond the refactor: the "no suitable crf" fallback trigger is matched case-insensitively as a substring (ab-av1 is auto-updated, so exact-match wording drift would have silently disabled the fallback ladder), and crf-search runs without `ffmpeg=trace` verbosity with progress callbacks throttled to changed values, cutting per-line work during analysis.

New tests cover the runner lifecycle against a scripted fake process (including the cancel/EOF race in both directions), the fallback-trigger contract, log-command anonymization, and `EncodeStats` attempt resets.

Fixes #17
