### PR TITLE
V3 engine: supervise cancellable external-tool processes (#54)

### DIFF
--- a/crates/crfty-engine/Cargo.toml
+++ b/crates/crfty-engine/Cargo.toml
@@ -14,6 +14,11 @@ name = "crfty-contract-fixture"
 path = "tests/support/contract_fixture.rs"
 required-features = ["contract-test-fixture"]
 
+[[bin]]
+name = "crfty-process-fixture"
+path = "tests/support/process_fixture.rs"
+required-features = ["contract-test-fixture"]
+
 [dependencies]
 ab-av1 = { version = "=0.11.4", git = "https://github.com/Loufe/ab-av1.git", rev = "8bde51723f6f95945792f58a94c08f59171047d7", default-features = false, features = ["library"] }
 blake2 = { version = "=0.10.6", default-features = false }

--- a/crates/crfty-engine/src/lib.rs
+++ b/crates/crfty-engine/src/lib.rs
@@ -20,6 +20,7 @@ pub mod logging;
 pub mod media;
 pub mod os_actions;
 pub mod output;
+pub mod process_supervisor;
 pub mod rate;
 pub mod release;
 pub mod remux;

--- a/crates/crfty-engine/src/media.rs
+++ b/crates/crfty-engine/src/media.rs
@@ -535,7 +535,9 @@ mod tests {
         VideoCodec, VideoMeta,
     };
 
-    use super::{hash_native_path, path_hash, sampled_identity, timestamp_reliability};
+    #[cfg(unix)]
+    use super::path_hash;
+    use super::{hash_native_path, sampled_identity, timestamp_reliability};
 
     static TEST_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 

--- a/crates/crfty-engine/src/process.rs
+++ b/crates/crfty-engine/src/process.rs
@@ -7,6 +7,8 @@ use command_group::{CommandGroup, GroupChild};
 
 #[cfg(windows)]
 const WINDOWS_CREATE_NO_WINDOW: u32 = 0x0800_0000;
+#[cfg(unix)]
+const UNIX_ESRCH: i32 = 3;
 
 pub(crate) struct ContainedChild {
     child: GroupChild,
@@ -30,25 +32,54 @@ impl ContainedChild {
     }
 
     pub(crate) fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
-        let status = self.child.try_wait()?;
-        if status.is_some() {
-            self.settled = true;
-        }
-        Ok(status)
+        // Leader exit does not prove that the complete process group/job is
+        // empty. Only `terminate_group_and_wait` settles containment.
+        self.child.try_wait()
     }
 
     pub(crate) fn terminate_and_wait(&mut self) -> io::Result<ExitStatus> {
-        if let Some(status) = self.try_wait()? {
-            return Ok(status);
-        }
+        self.terminate_group_and_wait()
+    }
+
+    /// Terminates the process group even when its leader's exit status was
+    /// already observed. On Unix, an orphaned descendant can outlive that
+    /// status while still holding the group's output pipes open.
+    pub(crate) fn terminate_group_and_wait(&mut self) -> io::Result<ExitStatus> {
         let kill_result = self.child.kill();
         let wait_result = self.child.wait();
-        self.settled = wait_result.is_ok();
-        match (kill_result, wait_result) {
-            (_, Ok(status)) => Ok(status),
+        let result = match (kill_result, wait_result) {
+            (Ok(()), Ok(status)) => Ok(status),
+            (Err(kill_error), Ok(status)) if containment_already_empty(&kill_error) => {
+                // The containment unit had already emptied between the last
+                // observation and termination. The cached leader status is
+                // still authoritative.
+                Ok(status)
+            }
+            (Err(kill_error), Ok(_status)) => Err(kill_error),
             (Err(kill_error), Err(_)) => Err(kill_error),
             (Ok(()), Err(wait_error)) => Err(wait_error),
-        }
+        };
+        self.settled = result.is_ok();
+        result
+    }
+}
+
+fn containment_already_empty(error: &io::Error) -> bool {
+    if matches!(
+        error.kind(),
+        io::ErrorKind::InvalidInput | io::ErrorKind::NotFound
+    ) {
+        return true;
+    }
+    #[cfg(unix)]
+    {
+        // command-group forwards killpg(2)'s ESRCH without mapping it to
+        // ErrorKind::NotFound. ESRCH means the process group no longer exists.
+        error.raw_os_error() == Some(UNIX_ESRCH)
+    }
+    #[cfg(not(unix))]
+    {
+        false
     }
 }
 
@@ -84,7 +115,7 @@ impl Drop for ContainedChild {
         if self.settled {
             return;
         }
-        if let Err(error) = self.terminate_and_wait() {
+        if let Err(error) = self.terminate_group_and_wait() {
             tracing::error!("failed to terminate contained child process group: {error}");
         }
     }

--- a/crates/crfty-engine/src/process_supervisor.rs
+++ b/crates/crfty-engine/src/process_supervisor.rs
@@ -1,0 +1,528 @@
+//! Bounded, cancellable supervision for short-lived external tools.
+//!
+//! The caller owns concurrency: hold a permit while calling [`run`]. The call
+//! returns only after the complete process group/job has exited and both pipe
+//! readers have joined, so returning also marks the safe point at which that
+//! permit may be released.
+
+use std::{
+    collections::VecDeque,
+    io::Read,
+    process::{Command, ExitStatus, Stdio},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread,
+    time::{Duration, Instant},
+};
+
+use crate::process::ContainedChild;
+
+const STATUS_POLL_INTERVAL: Duration = Duration::from_millis(20);
+const READ_BUFFER_BYTES: usize = 8 * 1024;
+
+/// A cooperative cancellation signal shared between a caller and a running
+/// supervisor.
+#[derive(Clone, Debug, Default)]
+pub struct ProcessCancellation {
+    cancelled: Arc<AtomicBool>,
+}
+
+impl ProcessCancellation {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Release);
+    }
+
+    #[must_use]
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Acquire)
+    }
+}
+
+/// Resource limits applied while supervising one process invocation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ProcessLimits {
+    /// `None` disables the deadline; cancellation remains available.
+    pub timeout: Option<Duration>,
+    /// Retain this many bytes from the beginning of stdout while continuing
+    /// to drain all later bytes.
+    pub stdout_head_bytes: usize,
+    /// Retain this many bytes from the end of stderr while continuing to drain
+    /// the complete stream.
+    pub stderr_tail_bytes: usize,
+}
+
+impl ProcessLimits {
+    #[must_use]
+    pub const fn new(
+        timeout: Option<Duration>,
+        stdout_head_bytes: usize,
+        stderr_tail_bytes: usize,
+    ) -> Self {
+        Self {
+            timeout,
+            stdout_head_bytes,
+            stderr_tail_bytes,
+        }
+    }
+}
+
+/// A bounded capture with the total number of bytes observed on its pipe.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct BoundedOutput {
+    bytes: Vec<u8>,
+    total_bytes: usize,
+}
+
+impl BoundedOutput {
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    #[must_use]
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
+
+    #[must_use]
+    pub const fn total_bytes(&self) -> usize {
+        self.total_bytes
+    }
+
+    #[must_use]
+    pub fn was_truncated(&self) -> bool {
+        self.total_bytes > self.bytes.len()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProcessFailureStage {
+    Spawn,
+    CaptureSetup,
+    Wait,
+    Terminate,
+    ReadStdout,
+    ReadStderr,
+    JoinStdout,
+    JoinStderr,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProcessFailure {
+    pub stage: ProcessFailureStage,
+    pub message: String,
+}
+
+/// The terminal reason for a supervised invocation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ProcessTerminal {
+    Success(ExitStatus),
+    ToolFailed(ExitStatus),
+    Cancelled,
+    TimedOut,
+    SpawnFailed(ProcessFailure),
+    SupervisionFailed(ProcessFailure),
+    CleanupFailed(ProcessFailure),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProcessReport {
+    pub terminal: ProcessTerminal,
+    pub stdout: BoundedOutput,
+    pub stderr_tail: BoundedOutput,
+}
+
+/// Runs one command in an operating-system process group/job.
+///
+/// Standard input is closed. Standard output and standard error are replaced
+/// with pipes and drained concurrently. Stdout retains a bounded head suitable
+/// for machine-readable output; stderr retains a bounded diagnostic tail.
+#[must_use]
+pub fn run(
+    command: &mut Command,
+    cancellation: &ProcessCancellation,
+    limits: ProcessLimits,
+) -> ProcessReport {
+    if cancellation.is_cancelled() {
+        return report(ProcessTerminal::Cancelled);
+    }
+
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = match ContainedChild::spawn(command) {
+        Ok(child) => child,
+        Err(error) => {
+            return report(ProcessTerminal::SpawnFailed(failure(
+                ProcessFailureStage::Spawn,
+                error,
+            )));
+        }
+    };
+
+    let stdout = match child.take_stdout() {
+        Some(stdout) => stdout,
+        None => {
+            return terminate_without_readers(
+                &mut child,
+                ProcessFailureStage::CaptureSetup,
+                "supervised process has no stdout pipe".to_owned(),
+            );
+        }
+    };
+    let stderr = match child.take_stderr() {
+        Some(stderr) => stderr,
+        None => {
+            drop(stdout);
+            return terminate_without_readers(
+                &mut child,
+                ProcessFailureStage::CaptureSetup,
+                "supervised process has no stderr pipe".to_owned(),
+            );
+        }
+    };
+
+    let stdout_reader = thread::Builder::new()
+        .name("crfty-process-stdout".to_owned())
+        .spawn(move || read_head(stdout, limits.stdout_head_bytes));
+    let stdout_reader = match stdout_reader {
+        Ok(reader) => reader,
+        Err(error) => {
+            drop(stderr);
+            return terminate_without_readers(
+                &mut child,
+                ProcessFailureStage::CaptureSetup,
+                format!("failed to start stdout reader: {error}"),
+            );
+        }
+    };
+    let stderr_reader = thread::Builder::new()
+        .name("crfty-process-stderr".to_owned())
+        .spawn(move || read_tail(stderr, limits.stderr_tail_bytes));
+    let stderr_reader = match stderr_reader {
+        Ok(reader) => reader,
+        Err(error) => {
+            let cleanup = child.terminate_group_and_wait().err().map(|terminate| {
+                failure(
+                    ProcessFailureStage::Terminate,
+                    format!(
+                        "failed to start stderr reader ({error}); process cleanup also failed: {terminate}"
+                    ),
+                )
+            });
+            let stdout = join_reader(stdout_reader, ProcessFailureStage::JoinStdout);
+            return ProcessReport {
+                terminal: cleanup.map_or_else(
+                    || {
+                        ProcessTerminal::SupervisionFailed(ProcessFailure {
+                            stage: ProcessFailureStage::CaptureSetup,
+                            message: format!("failed to start stderr reader: {error}"),
+                        })
+                    },
+                    ProcessTerminal::CleanupFailed,
+                ),
+                stdout: stdout.output,
+                stderr_tail: BoundedOutput::default(),
+            };
+        }
+    };
+
+    let started = Instant::now();
+    let mut exit_status = None;
+    loop {
+        if cancellation.is_cancelled() {
+            return terminate_and_finish(
+                &mut child,
+                ProcessTerminal::Cancelled,
+                stdout_reader,
+                stderr_reader,
+            );
+        }
+
+        if exit_status.is_none() {
+            match child.try_wait() {
+                Ok(Some(status)) => exit_status = Some(status),
+                Ok(None) => {}
+                Err(error) => {
+                    let terminal = ProcessTerminal::SupervisionFailed(failure(
+                        ProcessFailureStage::Wait,
+                        error,
+                    ));
+                    return terminate_and_finish(
+                        &mut child,
+                        terminal,
+                        stdout_reader,
+                        stderr_reader,
+                    );
+                }
+            }
+        }
+
+        if let Some(status) = exit_status
+            && stdout_reader.is_finished()
+            && stderr_reader.is_finished()
+        {
+            let terminal = if status.success() {
+                ProcessTerminal::Success(status)
+            } else {
+                ProcessTerminal::ToolFailed(status)
+            };
+            // `try_wait` can observe the group leader after a descendant has
+            // detached its inherited pipes. Terminate the containment unit
+            // even on natural leader exit so no silent descendant outlives
+            // the report or its caller-owned concurrency permit.
+            return terminate_and_finish(&mut child, terminal, stdout_reader, stderr_reader);
+        }
+
+        if limits
+            .timeout
+            .is_some_and(|timeout| started.elapsed() >= timeout)
+        {
+            return terminate_and_finish(
+                &mut child,
+                ProcessTerminal::TimedOut,
+                stdout_reader,
+                stderr_reader,
+            );
+        }
+        thread::sleep(STATUS_POLL_INTERVAL);
+    }
+}
+
+fn terminate_without_readers(
+    child: &mut ContainedChild,
+    stage: ProcessFailureStage,
+    message: String,
+) -> ProcessReport {
+    let terminal = match child.terminate_group_and_wait() {
+        Ok(_status) => ProcessTerminal::SupervisionFailed(ProcessFailure { stage, message }),
+        Err(error) => ProcessTerminal::CleanupFailed(ProcessFailure {
+            stage: ProcessFailureStage::Terminate,
+            message: format!("{message}; process cleanup also failed: {error}"),
+        }),
+    };
+    report(terminal)
+}
+
+fn terminate_and_finish(
+    child: &mut ContainedChild,
+    intended: ProcessTerminal,
+    stdout_reader: thread::JoinHandle<ReaderResult>,
+    stderr_reader: thread::JoinHandle<ReaderResult>,
+) -> ProcessReport {
+    let terminal = match child.terminate_group_and_wait() {
+        Ok(_status) => intended,
+        Err(error) => {
+            ProcessTerminal::CleanupFailed(failure(ProcessFailureStage::Terminate, error))
+        }
+    };
+    finish(terminal, stdout_reader, stderr_reader)
+}
+
+fn finish(
+    terminal: ProcessTerminal,
+    stdout_reader: thread::JoinHandle<ReaderResult>,
+    stderr_reader: thread::JoinHandle<ReaderResult>,
+) -> ProcessReport {
+    let stdout = join_reader(stdout_reader, ProcessFailureStage::JoinStdout);
+    let stderr = join_reader(stderr_reader, ProcessFailureStage::JoinStderr);
+    let terminal = if matches!(terminal, ProcessTerminal::CleanupFailed(_)) {
+        terminal
+    } else if let Some(failure) = stdout.failure.or(stderr.failure) {
+        ProcessTerminal::SupervisionFailed(failure)
+    } else {
+        terminal
+    };
+    ProcessReport {
+        terminal,
+        stdout: stdout.output,
+        stderr_tail: stderr.output,
+    }
+}
+
+struct JoinedReader {
+    output: BoundedOutput,
+    failure: Option<ProcessFailure>,
+}
+
+fn join_reader(
+    reader: thread::JoinHandle<ReaderResult>,
+    panic_stage: ProcessFailureStage,
+) -> JoinedReader {
+    match reader.join() {
+        Ok(result) => JoinedReader {
+            output: result.output,
+            failure: result.failure,
+        },
+        Err(_panic) => JoinedReader {
+            output: BoundedOutput::default(),
+            failure: Some(ProcessFailure {
+                stage: panic_stage,
+                message: "process output reader panicked".to_owned(),
+            }),
+        },
+    }
+}
+
+struct ReaderResult {
+    output: BoundedOutput,
+    failure: Option<ProcessFailure>,
+}
+
+fn read_head(mut reader: impl Read, limit: usize) -> ReaderResult {
+    let mut output = Vec::with_capacity(limit.min(READ_BUFFER_BYTES));
+    let mut total_bytes = 0_usize;
+    let mut buffer = [0_u8; READ_BUFFER_BYTES];
+    loop {
+        match reader.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(count) => {
+                total_bytes = total_bytes.saturating_add(count);
+                let remaining = limit.saturating_sub(output.len());
+                let retained = count.min(remaining);
+                if let Some(chunk) = buffer.get(..retained) {
+                    output.extend_from_slice(chunk);
+                }
+            }
+            Err(error) => {
+                return ReaderResult {
+                    output: BoundedOutput {
+                        bytes: output,
+                        total_bytes,
+                    },
+                    failure: Some(failure(ProcessFailureStage::ReadStdout, error)),
+                };
+            }
+        }
+    }
+    ReaderResult {
+        output: BoundedOutput {
+            bytes: output,
+            total_bytes,
+        },
+        failure: None,
+    }
+}
+
+fn read_tail(mut reader: impl Read, limit: usize) -> ReaderResult {
+    let mut output = VecDeque::with_capacity(limit.min(READ_BUFFER_BYTES));
+    let mut total_bytes = 0_usize;
+    let mut buffer = [0_u8; READ_BUFFER_BYTES];
+    loop {
+        match reader.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(count) => {
+                total_bytes = total_bytes.saturating_add(count);
+                if let Some(chunk) = buffer.get(..count) {
+                    output.extend(chunk);
+                    let excess = output.len().saturating_sub(limit);
+                    output.drain(..excess);
+                }
+            }
+            Err(error) => {
+                return ReaderResult {
+                    output: BoundedOutput {
+                        bytes: output.into(),
+                        total_bytes,
+                    },
+                    failure: Some(failure(ProcessFailureStage::ReadStderr, error)),
+                };
+            }
+        }
+    }
+    ReaderResult {
+        output: BoundedOutput {
+            bytes: output.into(),
+            total_bytes,
+        },
+        failure: None,
+    }
+}
+
+fn failure(stage: ProcessFailureStage, error: impl std::fmt::Display) -> ProcessFailure {
+    ProcessFailure {
+        stage,
+        message: error.to_string(),
+    }
+}
+
+fn report(terminal: ProcessTerminal) -> ProcessReport {
+    ProcessReport {
+        terminal,
+        stdout: BoundedOutput::default(),
+        stderr_tail: BoundedOutput::default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{self, Cursor, Read};
+
+    use super::{ProcessFailureStage, read_head, read_tail};
+
+    #[test]
+    fn head_retains_prefix_and_counts_discarded_bytes() {
+        let result = read_head(Cursor::new(b"abcdefghij"), 4);
+        assert_eq!(result.output.as_bytes(), b"abcd");
+        assert_eq!(result.output.total_bytes(), 10);
+        assert!(result.output.was_truncated());
+        assert_eq!(result.failure, None);
+    }
+
+    #[test]
+    fn tail_retains_suffix_and_counts_discarded_bytes() {
+        let result = read_tail(Cursor::new(b"abcdefghij"), 4);
+        assert_eq!(result.output.as_bytes(), b"ghij");
+        assert_eq!(result.output.total_bytes(), 10);
+        assert!(result.output.was_truncated());
+        assert_eq!(result.failure, None);
+    }
+
+    #[test]
+    fn zero_limits_still_drain_the_streams() {
+        let head = read_head(Cursor::new(b"stdout"), 0);
+        let tail = read_tail(Cursor::new(b"stderr"), 0);
+        assert!(head.output.as_bytes().is_empty());
+        assert_eq!(head.output.total_bytes(), 6);
+        assert!(tail.output.as_bytes().is_empty());
+        assert_eq!(tail.output.total_bytes(), 6);
+    }
+
+    #[test]
+    fn read_failure_preserves_retained_bytes_and_identifies_the_pipe() {
+        let result = read_head(FailingReader::default(), 8);
+        assert_eq!(result.output.as_bytes(), b"abc");
+        assert_eq!(result.output.total_bytes(), 3);
+        assert!(matches!(
+            result.failure,
+            Some(failure) if failure.stage == ProcessFailureStage::ReadStdout
+        ));
+    }
+
+    #[derive(Default)]
+    struct FailingReader {
+        emitted: bool,
+    }
+
+    impl Read for FailingReader {
+        fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+            if self.emitted {
+                return Err(io::Error::other("fixture read failure"));
+            }
+            self.emitted = true;
+            buffer
+                .get_mut(..3)
+                .ok_or_else(|| io::Error::other("fixture buffer is too small"))?
+                .copy_from_slice(b"abc");
+            Ok(3)
+        }
+    }
+}

--- a/crates/crfty-engine/src/process_supervisor.rs
+++ b/crates/crfty-engine/src/process_supervisor.rs
@@ -266,19 +266,18 @@ pub fn run(
             }
         }
 
-        if let Some(status) = exit_status
-            && stdout_reader.is_finished()
-            && stderr_reader.is_finished()
-        {
+        if let Some(status) = exit_status {
             let terminal = if status.success() {
                 ProcessTerminal::Success(status)
             } else {
                 ProcessTerminal::ToolFailed(status)
             };
-            // `try_wait` can observe the group leader after a descendant has
-            // detached its inherited pipes. Terminate the containment unit
-            // even on natural leader exit so no silent descendant outlives
-            // the report or its caller-owned concurrency permit.
+            // The directly spawned leader defines the invocation's terminal
+            // status. Any descendants still in its containment unit are
+            // cleanup, regardless of whether they retained or replaced the
+            // leader's pipe handles. This keeps pipe inheritance from changing
+            // success into a timeout and prevents silent descendants from
+            // outliving the caller-owned concurrency permit.
             return terminate_and_finish(&mut child, terminal, stdout_reader, stderr_reader);
         }
 

--- a/crates/crfty-engine/tests/process_supervisor.rs
+++ b/crates/crfty-engine/tests/process_supervisor.rs
@@ -1,0 +1,247 @@
+#![forbid(unsafe_code)]
+#![allow(clippy::expect_used, clippy::indexing_slicing, clippy::unwrap_used)]
+
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    process::Command,
+    thread,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use crfty_engine::process_supervisor::{
+    ProcessCancellation, ProcessFailureStage, ProcessLimits, ProcessTerminal, run,
+};
+
+const LARGE_STREAM_BYTES: usize = 2 * 1024 * 1024;
+const STDOUT_LIMIT: usize = 257;
+const STDERR_LIMIT: usize = 263;
+
+#[test]
+fn large_streams_are_drained_concurrently_and_retained_deterministically() {
+    let fixture = fixture();
+    let report = run(
+        Command::new(fixture)
+            .arg("emit")
+            .arg(LARGE_STREAM_BYTES.to_string())
+            .arg(LARGE_STREAM_BYTES.to_string())
+            .arg("0"),
+        &ProcessCancellation::new(),
+        limits(Some(Duration::from_secs(10))),
+    );
+
+    assert!(
+        matches!(report.terminal, ProcessTerminal::Success(_)),
+        "unexpected terminal: {:?}",
+        report.terminal
+    );
+    assert_eq!(report.stdout.total_bytes(), LARGE_STREAM_BYTES);
+    assert_eq!(report.stderr_tail.total_bytes(), LARGE_STREAM_BYTES);
+    assert_eq!(
+        report.stdout.as_bytes(),
+        expected_pattern(0, STDOUT_LIMIT, b'a')
+    );
+    assert_eq!(
+        report.stderr_tail.as_bytes(),
+        expected_pattern(LARGE_STREAM_BYTES - STDERR_LIMIT, STDERR_LIMIT, b'A')
+    );
+    assert!(report.stdout.was_truncated());
+    assert!(report.stderr_tail.was_truncated());
+}
+
+#[test]
+fn reports_tool_failure_and_preserves_its_diagnostic_tail() {
+    let fixture = fixture();
+    let report = run(
+        Command::new(fixture)
+            .arg("emit")
+            .arg("8")
+            .arg("1024")
+            .arg("7"),
+        &ProcessCancellation::new(),
+        limits(Some(Duration::from_secs(5))),
+    );
+
+    assert!(
+        matches!(report.terminal, ProcessTerminal::ToolFailed(_)),
+        "unexpected terminal: {:?}",
+        report.terminal
+    );
+    assert_eq!(report.stdout.as_bytes(), expected_pattern(0, 8, b'a'));
+    assert_eq!(report.stderr_tail.as_bytes().len(), STDERR_LIMIT);
+}
+
+#[test]
+fn reports_spawn_failure_without_panicking() {
+    let missing = env::temp_dir().join(format!(
+        "crfty-missing-process-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let report = run(
+        &mut Command::new(missing),
+        &ProcessCancellation::new(),
+        limits(Some(Duration::from_secs(1))),
+    );
+
+    assert!(matches!(
+        report.terminal,
+        ProcessTerminal::SpawnFailed(ref failure)
+            if failure.stage == ProcessFailureStage::Spawn
+    ));
+}
+
+#[test]
+fn timeout_terminates_the_process_group() {
+    let fixture = fixture();
+    let report = run(
+        Command::new(fixture).arg("sleep"),
+        &ProcessCancellation::new(),
+        limits(Some(Duration::from_millis(100))),
+    );
+
+    assert_eq!(report.terminal, ProcessTerminal::TimedOut);
+}
+
+#[test]
+fn leader_exit_does_not_hide_a_live_descendant_from_timeout_cleanup() {
+    let fixture = fixture();
+    let directory = test_directory("orphan-timeout");
+    fs::create_dir_all(&directory).expect("create process supervisor test directory");
+    let heartbeat = directory.join("heartbeat");
+    let report = run(
+        Command::new(fixture)
+            .arg("orphan-heartbeat")
+            .arg(&heartbeat),
+        &ProcessCancellation::new(),
+        limits(Some(Duration::from_millis(300))),
+    );
+
+    assert_eq!(report.terminal, ProcessTerminal::TimedOut);
+    let stopped_value = fs::read(&heartbeat).expect("read orphan heartbeat after timeout");
+    thread::sleep(Duration::from_millis(200));
+    assert_eq!(
+        fs::read(&heartbeat).expect("read stopped orphan heartbeat"),
+        stopped_value
+    );
+    fs::remove_dir_all(directory).expect("remove process supervisor test directory");
+}
+
+#[test]
+fn natural_leader_exit_cleans_a_descendant_that_closed_its_pipes() {
+    let fixture = fixture();
+    let directory = test_directory("orphan-closed-pipes");
+    fs::create_dir_all(&directory).expect("create process supervisor test directory");
+    let heartbeat = directory.join("heartbeat");
+    let report = run(
+        Command::new(fixture)
+            .arg("orphan-closed-pipes")
+            .arg(&heartbeat),
+        &ProcessCancellation::new(),
+        limits(Some(Duration::from_secs(5))),
+    );
+
+    assert!(
+        matches!(report.terminal, ProcessTerminal::Success(_)),
+        "unexpected terminal: {:?}",
+        report.terminal
+    );
+    let stopped_value = fs::read(&heartbeat).expect("read heartbeat after leader exit");
+    thread::sleep(Duration::from_millis(200));
+    assert_eq!(
+        fs::read(&heartbeat).expect("read stopped detached heartbeat"),
+        stopped_value
+    );
+    fs::remove_dir_all(directory).expect("remove process supervisor test directory");
+}
+
+#[test]
+fn cancellation_terminates_the_native_process_tree_and_joins_readers() {
+    let fixture = fixture();
+    let directory = test_directory("cancel-tree");
+    fs::create_dir_all(&directory).expect("create process supervisor test directory");
+    let heartbeat = directory.join("heartbeat");
+    let cancellation = ProcessCancellation::new();
+    let worker_cancellation = cancellation.clone();
+    let worker_fixture = fixture.clone();
+    let worker_heartbeat = heartbeat.clone();
+    let worker = thread::spawn(move || {
+        run(
+            Command::new(worker_fixture)
+                .arg("spawn-heartbeat")
+                .arg(worker_heartbeat),
+            &worker_cancellation,
+            limits(Some(Duration::from_secs(10))),
+        )
+    });
+
+    wait_for_file(&heartbeat);
+    cancellation.cancel();
+    let report = worker.join().expect("join process supervisor caller");
+    assert_eq!(report.terminal, ProcessTerminal::Cancelled);
+    let stopped_value = fs::read(&heartbeat).expect("read heartbeat after cancellation");
+    thread::sleep(Duration::from_millis(200));
+    assert_eq!(
+        fs::read(&heartbeat).expect("read stopped heartbeat"),
+        stopped_value
+    );
+    fs::remove_dir_all(directory).expect("remove process supervisor test directory");
+}
+
+#[test]
+fn cancellation_before_spawn_has_no_side_effect() {
+    let fixture = fixture();
+    let directory = test_directory("pre-cancel");
+    fs::create_dir_all(&directory).expect("create process supervisor test directory");
+    let heartbeat = directory.join("heartbeat");
+    let cancellation = ProcessCancellation::new();
+    cancellation.cancel();
+    let report = run(
+        Command::new(fixture).arg("spawn-heartbeat").arg(&heartbeat),
+        &cancellation,
+        limits(Some(Duration::from_secs(1))),
+    );
+
+    assert_eq!(report.terminal, ProcessTerminal::Cancelled);
+    assert!(!heartbeat.exists());
+    fs::remove_dir_all(directory).expect("remove process supervisor test directory");
+}
+
+fn limits(timeout: Option<Duration>) -> ProcessLimits {
+    ProcessLimits::new(timeout, STDOUT_LIMIT, STDERR_LIMIT)
+}
+
+fn fixture() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_crfty-process-fixture"))
+}
+
+fn expected_pattern(offset: usize, count: usize, base: u8) -> Vec<u8> {
+    (offset..offset + count)
+        .map(|position| base + u8::try_from(position % 26).unwrap_or_default())
+        .collect()
+}
+
+fn wait_for_file(path: &Path) {
+    for _attempt in 0..500 {
+        if path.exists() {
+            return;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    panic!("fixture did not create {}", path.display());
+}
+
+fn test_directory(label: &str) -> PathBuf {
+    env::temp_dir().join(format!(
+        "crfty-process-{label}-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ))
+}
+
+fn unique_suffix() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time after epoch")
+        .as_nanos()
+}

--- a/crates/crfty-engine/tests/process_supervisor.rs
+++ b/crates/crfty-engine/tests/process_supervisor.rs
@@ -104,9 +104,9 @@ fn timeout_terminates_the_process_group() {
 }
 
 #[test]
-fn leader_exit_does_not_hide_a_live_descendant_from_timeout_cleanup() {
+fn natural_leader_exit_cleans_a_descendant_that_kept_its_pipes() {
     let fixture = fixture();
-    let directory = test_directory("orphan-timeout");
+    let directory = test_directory("orphan-kept-pipes");
     fs::create_dir_all(&directory).expect("create process supervisor test directory");
     let heartbeat = directory.join("heartbeat");
     let report = run(
@@ -114,14 +114,18 @@ fn leader_exit_does_not_hide_a_live_descendant_from_timeout_cleanup() {
             .arg("orphan-heartbeat")
             .arg(&heartbeat),
         &ProcessCancellation::new(),
-        limits(Some(Duration::from_millis(300))),
+        limits(Some(Duration::from_secs(5))),
     );
 
-    assert_eq!(report.terminal, ProcessTerminal::TimedOut);
-    let stopped_value = fs::read(&heartbeat).expect("read orphan heartbeat after timeout");
+    assert!(
+        matches!(report.terminal, ProcessTerminal::Success(_)),
+        "unexpected terminal: {:?}",
+        report.terminal
+    );
+    let stopped_value = fs::read(&heartbeat).expect("read heartbeat after leader exit");
     thread::sleep(Duration::from_millis(200));
     assert_eq!(
-        fs::read(&heartbeat).expect("read stopped orphan heartbeat"),
+        fs::read(&heartbeat).expect("read stopped inherited-pipe heartbeat"),
         stopped_value
     );
     fs::remove_dir_all(directory).expect("remove process supervisor test directory");

--- a/crates/crfty-engine/tests/support/process_fixture.rs
+++ b/crates/crfty-engine/tests/support/process_fixture.rs
@@ -1,0 +1,140 @@
+#![forbid(unsafe_code)]
+
+use std::{
+    env,
+    error::Error,
+    fs,
+    io::{self, Write},
+    path::Path,
+    process::{self, Command},
+    thread,
+    time::Duration,
+};
+
+const CHUNK_BYTES: usize = 4 * 1024;
+
+fn main() {
+    if let Err(error) = dispatch() {
+        eprintln!("{error}");
+        process::exit(1);
+    }
+}
+
+fn dispatch() -> Result<(), Box<dyn Error>> {
+    let mut arguments = env::args_os();
+    let _executable = arguments.next();
+    match arguments
+        .next()
+        .and_then(|argument| argument.into_string().ok())
+    {
+        Some(command) if command == "emit" => {
+            let stdout_bytes = parse_usize(arguments.next(), "stdout byte count")?;
+            let stderr_bytes = parse_usize(arguments.next(), "stderr byte count")?;
+            let exit_code = parse_i32(arguments.next(), "exit code")?;
+            emit(stdout_bytes, stderr_bytes)?;
+            process::exit(exit_code);
+        }
+        Some(command) if command == "sleep" => loop {
+            thread::sleep(Duration::from_secs(1));
+        },
+        Some(command) if command == "spawn-heartbeat" => {
+            let marker = arguments.next().ok_or("heartbeat path is missing")?;
+            let _child = Command::new(env::current_exe()?)
+                .arg("heartbeat")
+                .arg(marker)
+                .spawn()?;
+            loop {
+                thread::sleep(Duration::from_secs(1));
+            }
+        }
+        Some(command) if command == "orphan-heartbeat" => {
+            let marker = arguments.next().ok_or("heartbeat path is missing")?;
+            let _child = Command::new(env::current_exe()?)
+                .arg("heartbeat")
+                .arg(marker)
+                .spawn()?;
+            Ok(())
+        }
+        Some(command) if command == "orphan-closed-pipes" => {
+            let marker = arguments.next().ok_or("heartbeat path is missing")?;
+            let _child = Command::new(env::current_exe()?)
+                .arg("heartbeat")
+                .arg(&marker)
+                .stdin(process::Stdio::null())
+                .stdout(process::Stdio::null())
+                .stderr(process::Stdio::null())
+                .spawn()?;
+            wait_for_file(Path::new(&marker))?;
+            Ok(())
+        }
+        Some(command) if command == "heartbeat" => {
+            let marker = arguments.next().ok_or("heartbeat path is missing")?;
+            heartbeat(Path::new(&marker))
+        }
+        _ => Err("unknown process fixture command".into()),
+    }
+}
+
+fn parse_usize(value: Option<std::ffi::OsString>, label: &str) -> Result<usize, Box<dyn Error>> {
+    value
+        .and_then(|value| value.into_string().ok())
+        .ok_or_else(|| format!("{label} is missing"))?
+        .parse()
+        .map_err(Into::into)
+}
+
+fn parse_i32(value: Option<std::ffi::OsString>, label: &str) -> Result<i32, Box<dyn Error>> {
+    value
+        .and_then(|value| value.into_string().ok())
+        .ok_or_else(|| format!("{label} is missing"))?
+        .parse()
+        .map_err(Into::into)
+}
+
+fn emit(stdout_bytes: usize, stderr_bytes: usize) -> io::Result<()> {
+    let mut stdout = io::stdout().lock();
+    let mut stderr = io::stderr().lock();
+    let mut stdout_offset = 0_usize;
+    let mut stderr_offset = 0_usize;
+    while stdout_offset < stdout_bytes || stderr_offset < stderr_bytes {
+        let stdout_count = (stdout_bytes - stdout_offset).min(CHUNK_BYTES);
+        if stdout_count > 0 {
+            write_pattern(&mut stdout, stdout_offset, stdout_count, b'a')?;
+            stdout.flush()?;
+            stdout_offset += stdout_count;
+        }
+        let stderr_count = (stderr_bytes - stderr_offset).min(CHUNK_BYTES);
+        if stderr_count > 0 {
+            write_pattern(&mut stderr, stderr_offset, stderr_count, b'A')?;
+            stderr.flush()?;
+            stderr_offset += stderr_count;
+        }
+    }
+    Ok(())
+}
+
+fn write_pattern(writer: &mut impl Write, offset: usize, count: usize, base: u8) -> io::Result<()> {
+    let bytes: Vec<u8> = (offset..offset + count)
+        .map(|position| base + u8::try_from(position % 26).unwrap_or_default())
+        .collect();
+    writer.write_all(&bytes)
+}
+
+fn heartbeat(path: &Path) -> Result<(), Box<dyn Error>> {
+    let mut counter = 0_u64;
+    loop {
+        fs::write(path, counter.to_string())?;
+        counter = counter.wrapping_add(1);
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn wait_for_file(path: &Path) -> Result<(), Box<dyn Error>> {
+    for _attempt in 0..500 {
+        if path.exists() {
+            return Ok(());
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    Err(format!("heartbeat fixture did not create {}", path.display()).into())
+}

--- a/crates/crfty-engine/tests/support/process_fixture.rs
+++ b/crates/crfty-engine/tests/support/process_fixture.rs
@@ -51,9 +51,9 @@ fn dispatch() -> Result<(), Box<dyn Error>> {
             let marker = arguments.next().ok_or("heartbeat path is missing")?;
             let _child = Command::new(env::current_exe()?)
                 .arg("heartbeat")
-                .arg(marker)
+                .arg(&marker)
                 .spawn()?;
-            Ok(())
+            wait_for_file(Path::new(&marker))
         }
         Some(command) if command == "orphan-closed-pipes" => {
             let marker = arguments.next().ok_or("heartbeat path is missing")?;


### PR DESCRIPTION
Closes #54.

Implements bounded, cancellable external-process supervision for the V3 engine:

- owns each child and its complete process tree through a native Unix process group or Windows Job Object
- drains stdout and stderr concurrently into deterministic bounded captures
- makes timeout and caller cancellation explicit outcomes
- cleans descendants on cancellation, timeout, supervisor drop, tool failure, and natural leader exit
- treats the directly spawned leader as the invocation authority, so descendant pipe inheritance cannot turn success into timeout
- preserves diagnostics without allowing pipe readers or detached descendants to outlive the call
- adds real-process contracts for success, failure, output pressure, timeout, cancellation, and descendants that retain or replace inherited pipes

Review and native CI exposed two edge cases that are fixed in this PR:

- a descendant that replaced its standard streams could outlive a successful report
- waiting on pipe completion after leader exit made Windows handle inheritance change success into timeout

The current contract terminates the remaining containment unit as soon as the leader exits, then joins both readers before returning. The branch also contains a target-gated import correction for an existing Unix-only media test that otherwise blocked the Windows matrix.

Local validation on the final rebased candidate:

- cargo fmt --all -- --check
- cargo test -p crfty-engine --test process_supervisor --all-features --locked: 8 passed
- cargo test --workspace --all-features --locked: 360 passed, 4 ignored
- strict workspace Clippy passed
- cargo deny check passed
- cargo vet passed